### PR TITLE
Feat/frontend/messages

### DIFF
--- a/apps/backend/src/services/auth.ts
+++ b/apps/backend/src/services/auth.ts
@@ -263,6 +263,21 @@ export async function completePasswordReset(token: string, newPassword: string):
   }
 }
 
+// Forces a token refresh so the Supabase client has a non-expired JWT.
+// Call this before any RLS-protected write operation.
+export async function ensureFreshSession(): Promise<AuthResult> {
+  const { data, error } = await supabase.auth.refreshSession();
+
+  if (error || !data.session) {
+    throw new Error("Session expired — please log in again.");
+  }
+
+  return {
+    user: data.session.user,
+    session: data.session,
+  };
+}
+
 // Sends Supabase password reset email.
 export async function sendPasswordResetEmail(email: string, redirectTo?: string): Promise<void> {
   if (!email.trim()) {

--- a/apps/backend/src/services/messaging.ts
+++ b/apps/backend/src/services/messaging.ts
@@ -147,41 +147,35 @@ export async function createConversation(userId: string, participantId: string, 
     return getConversation(existingId, userId);
   }
 
-  // Create new conversation.
-  const { data: convo, error: convoError } = await supabase
-    .from("conversations")
-    .insert({ listing_id: listingId ?? null })
-    .select("id,listing_id,created_at,updated_at")
-    .single();
+  // Generate the conversation ID up front so we don't need RETURNING.
+  // The SELECT RLS policy requires the user to be a participant, but
+  // participants are added after the insert — so .insert().select()
+  // would trigger a 403 on the read-back.
+  const convoId = crypto.randomUUID();
 
-  if (convoError || !convo) {
-    throw new Error(`Failed to create conversation: ${convoError?.message ?? "no data returned"}`);
+  const { error: convoError } = await supabase
+    .from("conversations")
+    .insert({ id: convoId, listing_id: listingId ?? null });
+
+  if (convoError) {
+    throw new Error(`Failed to create conversation: ${convoError.message}`);
   }
 
   // Add both users as participants.
   const { error: partError } = await supabase
     .from("conversation_participants")
     .insert([
-      { conversation_id: convo.id, user_id: userId },
-      { conversation_id: convo.id, user_id: participantId },
+      { conversation_id: convoId, user_id: userId },
+      { conversation_id: convoId, user_id: participantId },
     ]);
 
   if (partError) {
     throw new Error(`Failed to add participants: ${partError.message}`);
   }
 
-  const displayName = await getDisplayName(participantId);
-
-  return {
-    id: convo.id,
-    listing_id: convo.listing_id,
-    created_at: convo.created_at,
-    updated_at: convo.updated_at,
-    other_user_id: participantId,
-    other_user_display_name: displayName,
-    last_message: undefined,
-    unread_count: 0,
-  };
+  // Now that participants exist, the SELECT policy passes and we can
+  // read the full conversation object back.
+  return getConversation(convoId, userId);
 }
 
 // Get all conversations for a user, sorted newest-first.

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -20,6 +20,7 @@ function App() {
             <Route path="/listing" element={<Listing />}/>
             <Route path="/listing/:id" element={<Listing />}/>
             <Route path="/messages" element={<Messages />}/>
+            <Route path="/messages/:conversationId" element={<Messages />}/>
             <Route path="/profile" element={<Profile />}/>
             <Route path="/login" element={<Login />}/>
             <Route path="/signup" element={<Signup />}/>

--- a/apps/web/src/components/ChatPanel.tsx
+++ b/apps/web/src/components/ChatPanel.tsx
@@ -84,10 +84,10 @@ export default function ChatPanel({
                                 className={`flex flex-col ${isMine ? "items-end" : "items-start"}`}
                             >
                                 <div
-                                    className={`max-w-[75%] rounded-lg px-3 py-2 text-sm break-words ${
+                                    className={`max-w-[75%] rounded-lg px-3 py-2 text-sm font-medium break-words ${
                                         isMine
-                                            ? "bg-[var(--color-primary)] text-white"
-                                            : "bg-[#d8d8d8] text-black"
+                                            ? "bg-[#8f0010] text-white drop-shadow-sm"
+                                            : "bg-white text-black shadow-sm"
                                     }`}
                                 >
                                     {msg.content}
@@ -117,7 +117,7 @@ export default function ChatPanel({
                     type="button"
                     onClick={onSend}
                     disabled={!messageInput.trim()}
-                    className="rounded bg-[var(--color-primary)] px-4 py-2 text-sm font-semibold text-white transition-opacity disabled:opacity-40"
+                    className="rounded bg-[#8f0010] px-4 py-2 text-sm font-semibold text-white transition-opacity disabled:opacity-40"
                 >
                     Send
                 </button>

--- a/apps/web/src/components/ChatPanel.tsx
+++ b/apps/web/src/components/ChatPanel.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useRef } from "react";
+import type { Message } from "@campus-marketplace/backend";
+
+type ChatPanelProps = {
+    messages: Message[];
+    userId: string;
+    otherUserName: string;
+    messageInput: string;
+    onInputChange: (value: string) => void;
+    onSend: () => void;
+    loading: boolean;
+    onBack?: () => void;
+};
+
+// Format a timestamp like "3:42 PM".
+function formatTime(iso: string): string {
+    return new Date(iso).toLocaleTimeString([], {
+        hour: "numeric",
+        minute: "2-digit",
+    });
+}
+
+export default function ChatPanel({
+    messages,
+    userId,
+    otherUserName,
+    messageInput,
+    onInputChange,
+    onSend,
+    loading,
+    onBack,
+}: ChatPanelProps) {
+    // Auto-scroll to the bottom when new messages arrive.
+    const bottomRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    }, [messages.length]);
+
+    // Send on Enter key (but not Shift+Enter, in case they want multiline later).
+    function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+        if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            onSend();
+        }
+    }
+
+    return (
+        <div className="flex h-full flex-col border-l border-[#b9b9b9]">
+            {/* Header */}
+            <div className="flex items-center gap-2 border-b border-[#b9b9b9] bg-[#ececec] px-4 py-3">
+                {/* Back button — only visible on mobile */}
+                {onBack && (
+                    <button
+                        type="button"
+                        onClick={onBack}
+                        className="mr-1 text-lg sm:hidden"
+                        aria-label="Back to conversations"
+                    >
+                        ←
+                    </button>
+                )}
+                <span className="text-lg font-semibold text-black">{otherUserName}</span>
+            </div>
+
+            {/* Message area */}
+            <div className="flex flex-1 flex-col gap-2 overflow-y-auto px-4 py-4 sm:px-8">
+                {loading && (
+                    <p className="self-center text-sm text-gray-500">Loading messages...</p>
+                )}
+
+                {!loading && messages.length === 0 && (
+                    <p className="self-center text-sm text-gray-500">
+                        No messages yet — say hello!
+                    </p>
+                )}
+
+                {!loading &&
+                    messages.map((msg) => {
+                        const isMine = msg.sender_id === userId;
+                        return (
+                            <div
+                                key={msg.id}
+                                className={`flex flex-col ${isMine ? "items-end" : "items-start"}`}
+                            >
+                                <div
+                                    className={`max-w-[75%] rounded-lg px-3 py-2 text-sm break-words ${
+                                        isMine
+                                            ? "bg-[var(--color-primary)] text-white"
+                                            : "bg-[#d8d8d8] text-black"
+                                    }`}
+                                >
+                                    {msg.content}
+                                </div>
+                                <span className="mt-0.5 text-[10px] text-gray-400">
+                                    {formatTime(msg.created_at)}
+                                </span>
+                            </div>
+                        );
+                    })}
+
+                {/* Scroll anchor */}
+                <div ref={bottomRef} />
+            </div>
+
+            {/* Message input */}
+            <div className="m-2 mt-0 flex items-center gap-2 bg-[#ececec] p-2">
+                <input
+                    type="text"
+                    placeholder="Type a message..."
+                    value={messageInput}
+                    onChange={(e) => onInputChange(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                    className="flex-1 bg-transparent px-2 py-2 text-lg text-black outline-none placeholder:text-black"
+                />
+                <button
+                    type="button"
+                    onClick={onSend}
+                    disabled={!messageInput.trim()}
+                    className="rounded bg-[var(--color-primary)] px-4 py-2 text-sm font-semibold text-white transition-opacity disabled:opacity-40"
+                >
+                    Send
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/apps/web/src/components/ConversationList.tsx
+++ b/apps/web/src/components/ConversationList.tsx
@@ -1,0 +1,90 @@
+import type { Conversation } from "@campus-marketplace/backend";
+
+type ConversationListProps = {
+    conversations: Conversation[];
+    activeId: string | null;
+    searchFilter: string;
+    onSearchChange: (value: string) => void;
+    onSelect: (id: string) => void;
+    loading: boolean;
+};
+
+export default function ConversationList({
+    conversations,
+    activeId,
+    searchFilter,
+    onSearchChange,
+    onSelect,
+    loading,
+}: ConversationListProps) {
+    // Filter conversations by display name using the search input.
+    const filtered = conversations.filter((c) =>
+        (c.other_user_display_name ?? "")
+            .toLowerCase()
+            .includes(searchFilter.toLowerCase()),
+    );
+
+    return (
+        <aside className="flex flex-col border-r border-[#b9b9b9] bg-[#ececec] p-4">
+            {/* Search bar */}
+            <input
+                type="text"
+                placeholder="Search contacts"
+                value={searchFilter}
+                onChange={(e) => onSearchChange(e.target.value)}
+                className="mb-4 rounded bg-[#d0d0d0] px-3 py-2 text-sm text-black outline-none placeholder:text-black"
+            />
+
+            {/* Conversation list */}
+            <div className="flex-1 overflow-y-auto">
+                {loading && (
+                    <p className="p-3 text-sm text-gray-500">Loading conversations...</p>
+                )}
+
+                {!loading && filtered.length === 0 && (
+                    <div className="rounded bg-[#d8d8d8] p-3 text-sm text-black">
+                        {searchFilter ? "No matching contacts." : "No conversations yet."}
+                    </div>
+                )}
+
+                {!loading &&
+                    filtered.map((convo) => (
+                        <button
+                            key={convo.id}
+                            type="button"
+                            onClick={() => onSelect(convo.id)}
+                            className={`mb-1 flex w-full cursor-pointer flex-col rounded px-3 py-2 text-left transition-colors ${
+                                convo.id === activeId
+                                    ? "bg-[var(--color-primary)] text-white"
+                                    : "hover:bg-[#d8d8d8]"
+                            }`}
+                        >
+                            <div className="flex items-center justify-between">
+                                <span className="truncate text-sm font-semibold">
+                                    {convo.other_user_display_name ?? "Unknown User"}
+                                </span>
+
+                                {/* Unread badge */}
+                                {(convo.unread_count ?? 0) > 0 && convo.id !== activeId && (
+                                    <span className="ml-2 flex h-5 min-w-5 items-center justify-center rounded-full bg-[var(--color-primary)] px-1.5 text-xs font-bold text-white">
+                                        {convo.unread_count}
+                                    </span>
+                                )}
+                            </div>
+
+                            {/* Last message preview */}
+                            {convo.last_message && (
+                                <span
+                                    className={`mt-0.5 truncate text-xs ${
+                                        convo.id === activeId ? "text-white/80" : "text-gray-500"
+                                    }`}
+                                >
+                                    {convo.last_message}
+                                </span>
+                            )}
+                        </button>
+                    ))}
+            </div>
+        </aside>
+    );
+}

--- a/apps/web/src/components/ConversationList.tsx
+++ b/apps/web/src/components/ConversationList.tsx
@@ -55,8 +55,8 @@ export default function ConversationList({
                             onClick={() => onSelect(convo.id)}
                             className={`mb-1 flex w-full cursor-pointer flex-col rounded px-3 py-2 text-left transition-colors ${
                                 convo.id === activeId
-                                    ? "bg-[var(--color-primary)] text-white"
-                                    : "hover:bg-[#d8d8d8]"
+                                    ? "bg-[#8f0010] text-white"
+                                    : "text-black hover:bg-[#d8d8d8]"
                             }`}
                         >
                             <div className="flex items-center justify-between">
@@ -66,7 +66,7 @@ export default function ConversationList({
 
                                 {/* Unread badge */}
                                 {(convo.unread_count ?? 0) > 0 && convo.id !== activeId && (
-                                    <span className="ml-2 flex h-5 min-w-5 items-center justify-center rounded-full bg-[var(--color-primary)] px-1.5 text-xs font-bold text-white">
+                                    <span className="ml-2 flex h-5 min-w-5 items-center justify-center rounded-full bg-[#8f0010] px-1.5 text-xs font-bold text-white">
                                         {convo.unread_count}
                                     </span>
                                 )}

--- a/apps/web/src/pages/listing.tsx
+++ b/apps/web/src/pages/listing.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
-import { getListingWithDetails } from "@campus-marketplace/backend";
+import { useNavigate, useParams, useOutletContext } from "react-router-dom";
+import { getListingWithDetails, createConversation, ensureFreshSession } from "@campus-marketplace/backend";
+import type { OutletContext } from "../features/types";
 
 
 export default function Listing() {
     const navigate = useNavigate();
     const { id } = useParams();
+    const { user } = useOutletContext<OutletContext>();
     const [listingData, setListingData] = useState<any>(null);
+    const [messagingLoading, setMessagingLoading] = useState(false);
 
     useEffect(() => {
         if (!id) {
@@ -111,6 +114,41 @@ export default function Listing() {
                             >
                                 back
                             </button>
+
+                            {/* Only show "Message Seller" if logged in and not viewing your own listing */}
+                            {user && listingData.user_id !== user.id && (
+                                <button
+                                    type="button"
+                                    disabled={messagingLoading}
+                                    className="bg-[#f1b7be] px-8 py-2 text-2xl text-black transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-50"
+                                    onClick={async () => {
+                                        setMessagingLoading(true);
+                                        try {
+                                            // Force a token refresh so the JWT isn't expired.
+                                            const { session } = await ensureFreshSession();
+                                            // Store refreshed tokens.
+                                            localStorage.setItem("access_token", session!.access_token);
+                                            localStorage.setItem("refresh_token", session!.refresh_token);
+
+                                            const convo = await createConversation(user.id, listingData.user_id, listingData.id);
+                                            navigate(`/messages/${convo.id}`);
+                                        } catch (err) {
+                                            console.error("Failed to start conversation:", err);
+                                            if (String(err).includes("Session expired")) {
+                                                alert("Your session has expired. Please log in again.");
+                                                navigate("/login");
+                                            } else {
+                                                alert("Could not start conversation. Please try again.");
+                                            }
+                                        } finally {
+                                            setMessagingLoading(false);
+                                        }
+                                    }}
+                                >
+                                    {messagingLoading ? "Opening..." : "Message Seller"}
+                                </button>
+                            )}
+
                             <button
                                 type="button"
                                 className="bg-[#f1b7be] px-8 py-2 text-2xl text-black transition hover:bg-white"

--- a/apps/web/src/pages/messages.tsx
+++ b/apps/web/src/pages/messages.tsx
@@ -1,33 +1,235 @@
+import { useEffect, useState } from "react";
+import { useOutletContext, useParams, Link } from "react-router-dom";
+import {
+    getConversationsByUser,
+    getMessages,
+    sendMessage,
+    markMessagesRead,
+    subscribeToMessages,
+} from "@campus-marketplace/backend";
+import type { Conversation, Message } from "@campus-marketplace/backend";
+import type { OutletContext } from "../features/types";
+import ConversationList from "../components/ConversationList";
+import ChatPanel from "../components/ChatPanel";
+
 export default function Messages() {
+    const { user } = useOutletContext<OutletContext>();
+    const { conversationId: routeConvoId } = useParams<{ conversationId?: string }>();
+
+    // --- state ---
+    const [conversations, setConversations] = useState<Conversation[]>([]);
+    const [activeConversationId, setActiveConversationId] = useState<string | null>(
+        routeConvoId ?? null,
+    );
+    const [messages, setMessages] = useState<Message[]>([]);
+    const [messageInput, setMessageInput] = useState("");
+    const [searchFilter, setSearchFilter] = useState("");
+    const [loading, setLoading] = useState(true);
+    const [chatLoading, setChatLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [mobileView, setMobileView] = useState<"list" | "chat">("list");
+
+    // --- load conversations on mount ---
+    useEffect(() => {
+        if (!user) return;
+
+        setLoading(true);
+        getConversationsByUser(user.id)
+            .then(setConversations)
+            .catch((err) => setError(err.message))
+            .finally(() => setLoading(false));
+    }, [user?.id]);
+
+    // --- poll conversations every 15 s so the sidebar stays fresh ---
+    useEffect(() => {
+        if (!user) return;
+
+        const interval = setInterval(() => {
+            getConversationsByUser(user.id)
+                .then(setConversations)
+                .catch(console.error);
+        }, 15_000);
+
+        return () => clearInterval(interval);
+    }, [user?.id]);
+
+    // --- load messages + realtime subscription when active conversation changes ---
+    useEffect(() => {
+        if (!activeConversationId || !user) return;
+
+        let cancelled = false;
+
+        // Fetch messages for the selected conversation.
+        setChatLoading(true);
+        getMessages(activeConversationId)
+            .then((msgs) => {
+                if (!cancelled) setMessages(msgs);
+            })
+            .catch((err) => {
+                if (!cancelled) setError(err.message);
+            })
+            .finally(() => {
+                if (!cancelled) setChatLoading(false);
+            });
+
+        // Mark incoming messages as read.
+        markMessagesRead(activeConversationId, user.id).catch(console.error);
+
+        // Clear the unread badge in the sidebar right away.
+        setConversations((prev) =>
+            prev.map((c) =>
+                c.id === activeConversationId ? { ...c, unread_count: 0 } : c,
+            ),
+        );
+
+        // Subscribe to new messages in real time.
+        const { unsubscribe } = subscribeToMessages(activeConversationId, (newMsg) => {
+            if (cancelled) return;
+
+            // Deduplicate — the optimistic append from handleSend may already have it.
+            setMessages((prev) =>
+                prev.some((m) => m.id === newMsg.id) ? prev : [...prev, newMsg],
+            );
+
+            // Update the sidebar preview for this conversation.
+            setConversations((prev) =>
+                prev.map((c) =>
+                    c.id === activeConversationId
+                        ? { ...c, last_message: newMsg.content, unread_count: 0 }
+                        : c,
+                ),
+            );
+
+            // If the message is from the other person, mark it read.
+            if (newMsg.sender_id !== user.id) {
+                markMessagesRead(activeConversationId, user.id).catch(console.error);
+            }
+        });
+
+        return () => {
+            cancelled = true;
+            unsubscribe();
+        };
+    }, [activeConversationId, user?.id]);
+
+    // --- send a message ---
+    async function handleSend() {
+        if (!activeConversationId || !user || !messageInput.trim()) return;
+
+        const content = messageInput.trim();
+        setMessageInput("");
+
+        try {
+            const sent = await sendMessage(activeConversationId, user.id, content);
+
+            // Append optimistically (realtime will also fire — dedup handles it).
+            setMessages((prev) =>
+                prev.some((m) => m.id === sent.id) ? prev : [...prev, sent],
+            );
+
+            // Update sidebar preview.
+            setConversations((prev) =>
+                prev.map((c) =>
+                    c.id === activeConversationId
+                        ? { ...c, last_message: sent.content }
+                        : c,
+                ),
+            );
+        } catch (err) {
+            console.error("Failed to send message:", err);
+            setError("Failed to send message. Please try again.");
+        }
+    }
+
+    // --- select a conversation ---
+    function handleSelectConversation(id: string) {
+        setActiveConversationId(id);
+        setMessages([]);
+        setError(null);
+        setMobileView("chat");
+    }
+
+    // --- find the active conversation for the header name ---
+    const activeConvo = conversations.find((c) => c.id === activeConversationId);
+
+    // --- auth guard ---
+    if (!user) {
+        return (
+            <div className="flex h-full min-h-[calc(100vh-64px)] w-full items-center justify-center bg-black/50">
+                <div className="mx-auto w-full max-w-md rounded-lg bg-white p-8 shadow-lg">
+                    <h2 className="mb-4 text-center text-2xl font-bold text-black">
+                        Sign in required
+                    </h2>
+                    <p className="mb-6 text-center text-gray-600">
+                        You need to be logged in to view your messages.
+                    </p>
+                    <Link
+                        to="/login"
+                        className="block rounded bg-[var(--color-primary)] px-4 py-2 text-center font-semibold text-white"
+                    >
+                        Go to Login
+                    </Link>
+                </div>
+            </div>
+        );
+    }
+
+    // --- error banner ---
+    const errorBanner = error && (
+        <div className="bg-red-100 px-4 py-2 text-sm text-red-700">
+            {error}
+            <button
+                type="button"
+                onClick={() => setError(null)}
+                className="ml-2 font-bold"
+            >
+                ✕
+            </button>
+        </div>
+    );
+
     return (
         <section className="h-full w-full">
-            <div className="grid h-full w-full grid-cols-[230px_1fr] overflow-hidden border border-[#b9b9b9] bg-[#cfcfcf]">
-                <aside className="flex flex-col border-r border-[#b9b9b9] bg-[#ececec] p-4">
-                    <input
-                        type="text"
-                        placeholder="search contacts"
-                        className="mb-4 rounded bg-[#d0d0d0] px-3 py-2 text-sm text-black outline-none placeholder:text-black"
+            {errorBanner}
+
+            <div className="grid h-full w-full grid-cols-1 overflow-hidden border border-[#b9b9b9] bg-[#cfcfcf] sm:grid-cols-[230px_1fr]">
+                {/* Sidebar — hidden on mobile when viewing a chat */}
+                <div className={`${mobileView === "chat" ? "hidden sm:flex" : "flex"}`}>
+                    <ConversationList
+                        conversations={conversations}
+                        activeId={activeConversationId}
+                        searchFilter={searchFilter}
+                        onSearchChange={setSearchFilter}
+                        onSelect={handleSelectConversation}
+                        loading={loading}
                     />
+                </div>
 
-                    <div className="flex-1 rounded bg-[#d8d8d8] p-3 text-sm text-black">
-                        No contacts yet.
-                    </div>
-                </aside>
-
-                <div className="flex h-full flex-col border-l border-[#b9b9b9]">
-                    <div className="mx-auto mt-3 w-[55%] bg-[#ececec] py-3 text-center text-2xl text-black">Messages</div>
-
-                    <div className="flex flex-1 items-center justify-center overflow-auto px-4 pb-4 pt-6 sm:px-8">
-                        <p className="text-xl text-black">Select a contact to start chatting.</p>
-                    </div>
-
-                    <div className="m-2 mt-0 bg-[#ececec] p-2">
-                        <input
-                            type="text"
-                            placeholder="Type a message..."
-                            className="w-full bg-transparent px-2 py-2 text-lg text-black outline-none placeholder:text-black"
+                {/* Chat panel — hidden on mobile when viewing the list */}
+                <div className={`${mobileView === "list" ? "hidden sm:flex" : "flex"} h-full`}>
+                    {activeConvo ? (
+                        <ChatPanel
+                            messages={messages}
+                            userId={user.id}
+                            otherUserName={activeConvo.other_user_display_name ?? "Unknown User"}
+                            messageInput={messageInput}
+                            onInputChange={setMessageInput}
+                            onSend={handleSend}
+                            loading={chatLoading}
+                            onBack={() => setMobileView("list")}
                         />
-                    </div>
+                    ) : (
+                        <div className="flex h-full w-full flex-col border-l border-[#b9b9b9]">
+                            <div className="mx-auto mt-3 w-[55%] bg-[#ececec] py-3 text-center text-2xl text-black">
+                                Messages
+                            </div>
+                            <div className="flex flex-1 items-center justify-center px-4 pb-4 pt-6 sm:px-8">
+                                <p className="text-xl text-black">
+                                    Select a contact to start chatting.
+                                </p>
+                            </div>
+                        </div>
+                    )}
                 </div>
             </div>
         </section>

--- a/apps/web/src/pages/messages.tsx
+++ b/apps/web/src/pages/messages.tsx
@@ -153,6 +153,10 @@ export default function Messages() {
 
     // --- select a conversation ---
     function handleSelectConversation(id: string) {
+        if (id === activeConversationId) {
+            setMobileView("chat");
+            return;
+        }
         setActiveConversationId(id);
         setMessages([]);
         setError(null);
@@ -175,7 +179,7 @@ export default function Messages() {
                     </p>
                     <Link
                         to="/login"
-                        className="block rounded bg-[var(--color-primary)] px-4 py-2 text-center font-semibold text-white"
+                        className="block rounded bg-[#8f0010] px-4 py-2 text-center font-semibold text-white"
                     >
                         Go to Login
                     </Link>

--- a/apps/web/src/pages/messages.tsx
+++ b/apps/web/src/pages/messages.tsx
@@ -6,6 +6,7 @@ import {
     sendMessage,
     markMessagesRead,
     subscribeToMessages,
+    getSessionFromTokens,
 } from "@campus-marketplace/backend";
 import type { Conversation, Message } from "@campus-marketplace/backend";
 import type { OutletContext } from "../features/types";
@@ -28,6 +29,15 @@ export default function Messages() {
     const [chatLoading, setChatLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [mobileView, setMobileView] = useState<"list" | "chat">("list");
+
+    // --- restore Supabase session so RLS recognizes the user ---
+    useEffect(() => {
+        const accessToken = localStorage.getItem("access_token");
+        const refreshToken = localStorage.getItem("refresh_token");
+        if (accessToken && refreshToken) {
+            getSessionFromTokens(accessToken, refreshToken).catch(console.error);
+        }
+    }, []);
 
     // --- load conversations on mount ---
     useEffect(() => {

--- a/apps/web/src/pages/my-listings.tsx
+++ b/apps/web/src/pages/my-listings.tsx
@@ -1,10 +1,3 @@
-import React from "react";
-import type { SessionUser } from "../features/types";
-
-type OutletContext = {
-    user: SessionUser | null;
-};
-
 const MyListings = () => {
     return (
         <div>

--- a/apps/web/src/pages/my-listings.tsx
+++ b/apps/web/src/pages/my-listings.tsx
@@ -1,3 +1,10 @@
+import React from "react";
+import type { SessionUser } from "../features/types";
+
+type OutletContext = {
+    user: SessionUser | null;
+};
+
 const MyListings = () => {
     return (
         <div>


### PR DESCRIPTION
1. apps/web/src/components/ConversationList.tsx — NEW FILE
                                                                                                                                                                  
  The left sidebar of the messaging screen. It shows:       
  - A search box at the top to filter conversations by name
  - A list of conversations, each showing the other person's name, a preview of the last message, and a red badge if there are unread messages
  - The currently selected conversation is highlighted in dark red
  - Shows "Loading..." or "No conversations yet" when appropriate
<img width="1917" height="912" alt="image" src="https://github.com/user-attachments/assets/1f2ba4e3-9713-4c18-8cfb-5cda890f158b" />

  ---
  2. apps/web/src/components/ChatPanel.tsx — NEW FILE

  The right side of the messaging screen where you actually read and send messages. It shows:
  - A header with the other person's name and a back arrow (for mobile)
  - Message bubbles — your messages appear on the right in dark red rounded boxes, the other person's on the left in white rounded boxes
  - Each message shows the time it was sent
  - A text input and send button at the bottom (you can also press Enter to send)
  - Auto-scrolls to the newest message when new messages arrive
<img width="1917" height="912" alt="image" src="https://github.com/user-attachments/assets/d1a24b0c-dabd-45ea-b1e1-567f090c6337" />

  ---
  3. apps/web/src/pages/messages.tsx — FULL REWRITE

  This is the main messaging page that ties everything together. Before this PR it was a static placeholder. Now it:
  - Loads your conversations from the database when the page opens
  - Refreshes the sidebar every 15 seconds so unread badges and message previews stay up to date
  - Loads messages when you click a conversation, and marks them as read
  - Listens for new messages in real time — if the other person sends you something, it appears instantly without refreshing
  - Sends messages when you type and hit Send/Enter
  - Handles duplicates — since messages arrive both from your send call and the real-time listener, it makes sure each message only appears once
  - Works on mobile — on small screens, you see either the conversation list OR the chat (not both), with a back button to switch
  - Shows a login prompt if you're not signed in
  - Restores your login session on page load so the database recognizes you
  - Clicking the same conversation again no longer wipes and reloads the messages

  ---
  4. apps/web/src/App.tsx — SMALL CHANGE

  Added a new route: /messages/:conversationId. This lets you link directly to a specific conversation (e.g., when clicking "Message Seller" on a listing, it  sends you straight to that conversation).
<img width="850" height="176" alt="image" src="https://github.com/user-attachments/assets/16db08b2-8f21-46df-be96-9be35ec92540" />


  ---
  5. apps/web/src/pages/listing.tsx — "MESSAGE SELLER" BUTTON

  Added a "Message Seller" button on the listing detail page. It only appears if you're logged in and you're not the seller. When clicked, it:
  - Refreshes your login session to make sure you're still authorized
  - Creates a conversation with the seller (or opens the existing one if you've messaged them before about the same listing)
  - Sends you to /messages/<conversation-id> to start chatting
  - Shows "Opening..." while it works, and handles errors (expired session, etc.)

  ---
  6. apps/backend/src/services/auth.ts — NEW FUNCTION

  Added ensureFreshSession() — a helper that refreshes your login token before doing something that requires database authorization. The "Message Seller" button  
  calls this to make sure your token isn't expired before creating a conversation.

  ---
  7. apps/backend/src/services/messaging.ts — BUG FIX

  Fixed the bug that was causing the 403 error when trying to message a seller. The problem was:
  - When creating a conversation, the old code would insert the conversation row AND try to read it back in one step
  - But the database security rule for reading conversations checks "is this user a participant?"
  - The user hadn't been added as a participant yet (that was the next step) — so the read-back was blocked
  - Fix: Generate the conversation's ID up front, insert without reading back, add both users as participants, then read the conversation (now the security check 
  passes because the user is a participant)

---
Note: Messages and conversations are not cached in local storage. Every page load fetches fresh data from the database. Real-time updates handle new messages while you're on the page, but navigating away and coming back triggers a full reload from the database. This is intentional, caching can be added later if needed but would add complexity around stale data for minimal benefit at this scale.                                                                            