### PR TITLE
migration for deleting favorites and school themes tables

### DIFF
--- a/supabase/migrations/20260408120000_drop_favorites_and_school_themes.sql
+++ b/supabase/migrations/20260408120000_drop_favorites_and_school_themes.sql
@@ -1,0 +1,5 @@
+-- Drop favorites and school_themes tables.
+-- This is destructive and removes table data and dependent objects.
+
+drop table if exists public.favorites cascade;
+drop table if exists public.school_themes cascade;


### PR DESCRIPTION
favorites table and school themes table are no longer being used, so this migration deletes them from the database

any code that may be present otherwise for these tables will be removed in a future PR