### PR TITLE
Feat/search expansion

### DIFF
--- a/apps/backend/src/services/listings.ts
+++ b/apps/backend/src/services/listings.ts
@@ -813,11 +813,22 @@ export async function searchListings(options: SearchListingsOptions = {}): Promi
     .is("deleted_at", null)
     .order("created_at", { ascending: false });
 
-  // Full-text search via GIN-indexed tsvector column.
+  // Prefix full-text search via GIN-indexed tsvector column.
+  // Each word gets :* appended so "boo" matches "book", "calc" matches "calculus", etc.
+  // Omitting `type` makes Supabase use to_tsquery, which supports the :* prefix syntax.
   if (query?.trim()) {
-    queryBuilder = queryBuilder.textSearch("tsv", query.trim(), {
-      type: "websearch",
-    });
+    const prefixQuery = query
+      .trim()
+      .split(/\s+/)
+      .map((w) => w.replace(/[^a-zA-Z0-9]/g, ""))
+      .filter(Boolean)
+      .map((w) => `${w}:*`)
+      .join(" & ");
+
+    if (prefixQuery) {
+      // config: "simple" skips dictionary stemming so short prefixes like "t" aren't dropped.
+      queryBuilder = queryBuilder.textSearch("tsv", prefixQuery, { config: "simple" });
+    }
   }
 
   // Optional filters.

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["ES2022"],
     "module": "Node16",
     "moduleResolution": "node16",
+    "rootDir": "./src",
     "outDir": "./dist",
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
## What changed                                                                                                                                                  
Search now works when you type partial words. Typing "t" shows toys, typing "calc" shows calculators, etc. Previously you had to type the full exact word to get any results.                                                                                                                                                                                                                                                                                                                        

## Technical                                                                                                                                                     
Fixed `searchListings` in `listings.ts` to use prefix tsquery (`word:*`) with `config: 'simple'` instead of `websearch_to_tsquery`. Also added explicit `rootDir` to `apps/backend/tsconfig.json` to clear a TS compiler warning.