### PR TITLE
Feat/seed data

### DIFF
--- a/docs/superpowers/plans/2026-04-15-seed-data.md
+++ b/docs/superpowers/plans/2026-04-15-seed-data.md
@@ -1,0 +1,779 @@
+# Seed Data (CM-US-050) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create a `npm run seed` command that wipes and re-seeds 5 demo accounts + 25 active listings in the staging Supabase instance.
+
+**Architecture:** A standalone TypeScript script at `scripts/seed-staging.ts` that imports service functions from `apps/backend/src/` directly. It uses the Supabase admin API (`supabase.auth.admin.createUser`) for user creation, existing backend service functions for listings, and direct supabase client inserts for `listing_images` and `listing_tags`. A single 1×1 PNG (base64-embedded) is uploaded to the `listing-images` storage bucket once per run so listing images render in the UI.
+
+**Tech Stack:** Node 22, tsx (ESM loader), `@supabase/supabase-js` admin API, existing backend service functions (`createListing`, `upsertItemDetails`, `upsertServiceDetails`, `publishListing`, `upsertProfile`, `getCategories`, `getTags`)
+
+**Save plan to:** `docs/superpowers/plans/2026-04-15-seed-data.md` (copy this file there before executing)
+
+---
+
+## File Map
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `package.json` | Modify | Add `"seed"` script + `tsx` devDependency |
+| `scripts/seed-staging.ts` | Create | The seed script (single file, all logic) |
+
+No new backend service files. No new migrations. No binary assets committed to git.
+
+---
+
+## Task 1: Project Setup
+
+**Files:**
+- Modify: `package.json`
+- Create: `scripts/seed-staging.ts` (empty skeleton)
+
+- [ ] **Step 1: Add `tsx` to root devDependencies and add the `seed` script**
+
+  Edit `package.json` — replace the `devDependencies` block and add the `seed` script:
+
+  ```json
+  {
+    "scripts": {
+      "dev": "npm run dev --workspace=apps/web",
+      "build": "npm run build --workspace=apps/backend && npm run build --workspace=apps/web",
+      "lint": "npm run lint --workspace=apps/web && npm run lint --workspace=apps/backend",
+      "typecheck": "npm run typecheck --workspaces",
+      "test": "npm run test --workspace=apps/backend",
+      "test:coverage": "npm run test:coverage --workspace=apps/backend",
+      "setup": "npm install && npm run build --workspace=apps/backend && npm run dev",
+      "setup:windows": "powershell -ExecutionPolicy Bypass -File dev.ps1",
+      "setup:unix": "bash dev.sh",
+      "seed": "node --env-file=apps/backend/.env.local --import tsx/esm scripts/seed-staging.ts"
+    },
+    "devDependencies": {
+      "supabase": "^1.199.0",
+      "tsx": "^4.19.2"
+    },
+    "engines": {
+      "node": "22.x",
+      "npm": "10.x"
+    }
+  }
+  ```
+
+- [ ] **Step 2: Install the new dependency**
+
+  ```bash
+  npm install
+  ```
+
+  Expected: `tsx` appears in `node_modules/.bin/tsx` and `package-lock.json` is updated.
+
+- [ ] **Step 3: Create the script skeleton**
+
+  Create `scripts/seed-staging.ts`:
+
+  ```typescript
+  // scripts/seed-staging.ts
+  // Staging seed script — wipes and re-creates demo accounts + listings.
+  // Run: npm run seed
+  // NEVER run against production.
+
+  async function main(): Promise<void> {
+    console.log("Seed script placeholder — tasks to be implemented.");
+  }
+
+  main().catch((err) => {
+    console.error("Seed failed:", err instanceof Error ? err.message : err);
+    process.exit(1);
+  });
+  ```
+
+- [ ] **Step 4: Verify the script runs**
+
+  ```bash
+  npm run seed
+  ```
+
+  Expected output:
+  ```
+  Seed script placeholder — tasks to be implemented.
+  ```
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add package.json package-lock.json scripts/seed-staging.ts
+  git commit -m "chore: add seed script skeleton and tsx dependency"
+  ```
+
+---
+
+## Task 2: Safety Check + Confirmation Prompt
+
+**Files:**
+- Modify: `scripts/seed-staging.ts`
+
+- [ ] **Step 1: Add the production guard and confirmation prompt to the script**
+
+  Replace `scripts/seed-staging.ts` entirely:
+
+  ```typescript
+  // scripts/seed-staging.ts
+  // Staging seed script — wipes and re-creates demo accounts + listings.
+  // Run: npm run seed
+  // NEVER run against production.
+
+  import * as readline from "node:readline/promises";
+  import { stdin, stdout } from "node:process";
+
+  // ─── Safety check ─────────────────────────────────────────────────────────────
+  // Set SUPABASE_PROD_REF in your shell (not committed) to match your production
+  // Supabase project ref string (e.g. "abcxyzproject123"). The script exits if
+  // the staging URL contains it.
+
+  function checkNotProduction(): void {
+    const url = process.env.SUPABASE_URL ?? "";
+    const env = process.env.NODE_ENV ?? "";
+    const prodRef = process.env.SUPABASE_PROD_REF ?? "";
+
+    if (env === "production") {
+      console.error("ERROR: NODE_ENV=production — refusing to seed.");
+      process.exit(1);
+    }
+    if (prodRef && url.includes(prodRef)) {
+      console.error("ERROR: SUPABASE_URL matches SUPABASE_PROD_REF — refusing to seed.");
+      console.error(`  URL: ${url}`);
+      process.exit(1);
+    }
+  }
+
+  // ─── Main ──────────────────────────────────────────────────────────────────────
+
+  async function main(): Promise<void> {
+    checkNotProduction();
+
+    console.log("\nCampus Marketplace — Staging Seed Script");
+    console.log("─────────────────────────────────────────");
+    console.log(`Targeting: ${process.env.SUPABASE_URL}`);
+    console.log("\nThis will:");
+    console.log("  • Delete demo accounts (demo.alex/sam/jordan/riley/casey @demo.edu) + all their listings");
+    console.log("  • Create 5 fresh demo accounts with ~25 listings\n");
+
+    const rl = readline.createInterface({ input: stdin, output: stdout });
+    const answer = await rl.question("Proceed? (y/n) ");
+    rl.close();
+
+    if (answer.toLowerCase() !== "y") {
+      console.log("Aborted.");
+      process.exit(0);
+    }
+
+    console.log("\nNothing seeded yet — more tasks to implement.");
+  }
+
+  main().catch((err) => {
+    console.error("\nSeed failed:", err instanceof Error ? err.message : err);
+    process.exit(1);
+  });
+  ```
+
+- [ ] **Step 2: Run the script and type `n` to abort**
+
+  ```bash
+  npm run seed
+  ```
+
+  Expected:
+  ```
+  Campus Marketplace — Staging Seed Script
+  ─────────────────────────────────────────
+  Targeting: https://...supabase.co
+
+  This will:
+    • Delete demo accounts ...
+    • Create 5 fresh demo accounts with ~25 listings
+
+  Proceed? (y/n) n
+  Aborted.
+  ```
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add scripts/seed-staging.ts
+  git commit -m "feat(seed): add production safety guard and confirmation prompt"
+  ```
+
+---
+
+## Task 3: wipeDemo Function
+
+**Files:**
+- Modify: `scripts/seed-staging.ts`
+
+- [ ] **Step 1: Add Supabase import and wipeDemo function**
+
+  Replace `scripts/seed-staging.ts` with the following (adds imports + `DEMO_ACCOUNTS` + `wipeDemo`):
+
+  ```typescript
+  // scripts/seed-staging.ts
+  // Staging seed script — wipes and re-creates demo accounts + listings.
+  // Run: npm run seed
+  // NEVER run against production.
+
+  import * as readline from "node:readline/promises";
+  import { stdin, stdout } from "node:process";
+  import { supabase } from "../apps/backend/src/supabase-client.js";
+
+  // ─── Demo account definitions ─────────────────────────────────────────────────
+
+  const DEMO_ACCOUNTS = [
+    { email: "demo.alex@demo.edu",   password: "demo1234", displayName: "Alex (Demo)",   accountType: "student"  as const },
+    { email: "demo.sam@demo.edu",    password: "demo1234", displayName: "Sam (Demo)",    accountType: "student"  as const },
+    { email: "demo.jordan@demo.edu", password: "demo1234", displayName: "Jordan (Demo)", accountType: "student"  as const },
+    { email: "demo.riley@demo.edu",  password: "demo1234", displayName: "Riley (Demo)",  accountType: "business" as const },
+    { email: "demo.casey@demo.edu",  password: "demo1234", displayName: "Casey (Demo)",  accountType: "student"  as const },
+  ];
+
+  // ─── Safety check ─────────────────────────────────────────────────────────────
+
+  function checkNotProduction(): void {
+    const url = process.env.SUPABASE_URL ?? "";
+    const env = process.env.NODE_ENV ?? "";
+    const prodRef = process.env.SUPABASE_PROD_REF ?? "";
+
+    if (env === "production") {
+      console.error("ERROR: NODE_ENV=production — refusing to seed.");
+      process.exit(1);
+    }
+    if (prodRef && url.includes(prodRef)) {
+      console.error("ERROR: SUPABASE_URL matches SUPABASE_PROD_REF — refusing to seed.");
+      console.error(`  URL: ${url}`);
+      process.exit(1);
+    }
+  }
+
+  // ─── Wipe demo accounts ────────────────────────────────────────────────────────
+  // Finds each demo email in auth.users and deletes it.
+  // Cascade: profiles, listings, listing_images, item_details, service_details, listing_tags.
+
+  async function wipeDemo(): Promise<number> {
+    const targetEmails = new Set(DEMO_ACCOUNTS.map((a) => a.email));
+    let wiped = 0;
+
+    const { data, error } = await supabase.auth.admin.listUsers({ perPage: 1000 });
+    if (error) throw new Error(`Failed to list users: ${error.message}`);
+
+    for (const user of data.users) {
+      if (user.email && targetEmails.has(user.email)) {
+        const { error: deleteError } = await supabase.auth.admin.deleteUser(user.id);
+        if (deleteError) throw new Error(`Failed to delete ${user.email}: ${deleteError.message}`);
+        wiped++;
+      }
+    }
+    return wiped;
+  }
+
+  // ─── Main ──────────────────────────────────────────────────────────────────────
+
+  async function main(): Promise<void> {
+    checkNotProduction();
+
+    console.log("\nCampus Marketplace — Staging Seed Script");
+    console.log("─────────────────────────────────────────");
+    console.log(`Targeting: ${process.env.SUPABASE_URL}`);
+    console.log("\nThis will:");
+    console.log("  • Delete demo accounts (demo.alex/sam/jordan/riley/casey @demo.edu) + all their listings");
+    console.log("  • Create 5 fresh demo accounts with ~25 listings\n");
+
+    const rl = readline.createInterface({ input: stdin, output: stdout });
+    const answer = await rl.question("Proceed? (y/n) ");
+    rl.close();
+
+    if (answer.toLowerCase() !== "y") {
+      console.log("Aborted.");
+      process.exit(0);
+    }
+
+    console.log("\n[1/4] Wiping demo accounts...");
+    const wiped = await wipeDemo();
+    console.log(`  Deleted ${wiped} existing demo account(s)`);
+
+    console.log("\nPartial run — remaining tasks not yet implemented.");
+  }
+
+  main().catch((err) => {
+    console.error("\nSeed failed:", err instanceof Error ? err.message : err);
+    process.exit(1);
+  });
+  ```
+
+- [ ] **Step 2: Run the script and enter `y`**
+
+  ```bash
+  npm run seed
+  ```
+
+  Expected output (first run, no demo users yet):
+  ```
+  [1/4] Wiping demo accounts...
+    Deleted 0 existing demo account(s)
+  Partial run — remaining tasks not yet implemented.
+  ```
+
+  If it throws, check that `apps/backend/.env.local` contains `SUPABASE_URL` and `SUPABASE_SERVICE_KEY`.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add scripts/seed-staging.ts
+  git commit -m "feat(seed): add wipeDemo — deletes demo accounts by email with cascade"
+  ```
+
+---
+
+## Task 4: seedUsers Function
+
+**Files:**
+- Modify: `scripts/seed-staging.ts`
+
+- [ ] **Step 1: Add `upsertProfile` import and `seedUsers` function**
+
+  Add this import at the top of the file (after the existing supabase import):
+
+  ```typescript
+  import { upsertProfile } from "../apps/backend/src/services/profile.js";
+  ```
+
+  Add this function before `main()`:
+
+  ```typescript
+  // ─── Seed users ────────────────────────────────────────────────────────────────
+  // Creates 5 demo accounts via admin API (no email verification needed).
+  // Returns a map of email → Supabase user UUID for use in listing creation.
+
+  async function seedUsers(): Promise<Map<string, string>> {
+    const userMap = new Map<string, string>();
+
+    for (const account of DEMO_ACCOUNTS) {
+      const { data, error } = await supabase.auth.admin.createUser({
+        email: account.email,
+        password: account.password,
+        email_confirm: true,
+        user_metadata: {
+          display_name: account.displayName,
+          account_type: account.accountType,
+        },
+      });
+
+      if (error || !data.user) {
+        throw new Error(`Failed to create ${account.email}: ${error?.message ?? "unknown"}`);
+      }
+
+      await upsertProfile({
+        user_id: data.user.id,
+        display_name: account.displayName,
+        account_type: account.accountType,
+      });
+
+      userMap.set(account.email, data.user.id);
+      console.log(`  Created: ${account.email}`);
+    }
+    return userMap;
+  }
+  ```
+
+  Update the `main()` function — replace `"Partial run..."` with the seedUsers call:
+
+  ```typescript
+    console.log("\n[2/4] Creating demo users...");
+    const userMap = await seedUsers();
+
+    console.log("\nPartial run — listing tasks not yet implemented.");
+  ```
+
+- [ ] **Step 2: Run the full script and enter `y`**
+
+  ```bash
+  npm run seed
+  ```
+
+  Expected output:
+  ```
+  [1/4] Wiping demo accounts...
+    Deleted 0 existing demo account(s)
+  [2/4] Creating demo users...
+    Created: demo.alex@demo.edu
+    Created: demo.sam@demo.edu
+    Created: demo.jordan@demo.edu
+    Created: demo.riley@demo.edu
+    Created: demo.casey@demo.edu
+  Partial run — listing tasks not yet implemented.
+  ```
+
+- [ ] **Step 3: Verify users exist in Supabase dashboard**
+
+  Open Supabase Dashboard → Authentication → Users. Confirm 5 `demo.*@demo.edu` accounts appear with email confirmed.
+
+- [ ] **Step 4: Run the script a second time to verify wipe-and-reseed works**
+
+  ```bash
+  npm run seed
+  ```
+
+  Expected: `Deleted 5 existing demo account(s)` then recreates them. No errors.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add scripts/seed-staging.ts
+  git commit -m "feat(seed): add seedUsers — creates 5 demo accounts via admin API"
+  ```
+
+---
+
+## Task 5: Upload Placeholder Image
+
+**Files:**
+- Modify: `scripts/seed-staging.ts`
+
+- [ ] **Step 1: Add placeholder constant and `uploadPlaceholder` function**
+
+  Add this constant after `DEMO_ACCOUNTS`:
+
+  ```typescript
+  // Minimal 1×1 grey PNG, base64-encoded — no external file or downloads needed.
+  const PLACEHOLDER_PNG = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQI12NgAAAAAgAB4iG8MwAAAABJRU5ErkJggg==",
+    "base64",
+  );
+  const PLACEHOLDER_STORAGE_PATH = "seed/placeholder.png";
+  ```
+
+  Add this function before `main()`:
+
+  ```typescript
+  // ─── Upload placeholder image ──────────────────────────────────────────────────
+  // Uploads a single 1×1 PNG to the listing-images bucket.
+  // All seed listings share this path — avoids 25 separate uploads.
+
+  async function uploadPlaceholder(): Promise<void> {
+    const { error } = await supabase.storage
+      .from("listing-images")
+      .upload(PLACEHOLDER_STORAGE_PATH, PLACEHOLDER_PNG, {
+        contentType: "image/png",
+        upsert: true,
+      });
+    if (error) throw new Error(`Failed to upload placeholder: ${error.message}`);
+  }
+  ```
+
+  Update `main()` — insert the placeholder upload step between wipe and seedUsers:
+
+  ```typescript
+    console.log("\n[1/4] Wiping demo accounts...");
+    const wiped = await wipeDemo();
+    console.log(`  Deleted ${wiped} existing demo account(s)`);
+
+    console.log("\n[2/4] Uploading placeholder image...");
+    await uploadPlaceholder();
+    console.log(`  Uploaded ${PLACEHOLDER_STORAGE_PATH}`);
+
+    console.log("\n[3/4] Creating demo users...");
+    const userMap = await seedUsers();
+
+    console.log("\nPartial run — listing tasks not yet implemented.");
+  ```
+
+  Note: step numbers shift — update main() numbering to `[1/5]`, `[2/5]`, `[3/5]` etc. as you add more steps.
+
+- [ ] **Step 2: Run and verify**
+
+  ```bash
+  npm run seed
+  ```
+
+  Expected: `Uploaded seed/placeholder.png` line appears without errors.
+
+  Open Supabase Dashboard → Storage → listing-images bucket. Confirm `seed/placeholder.png` exists.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add scripts/seed-staging.ts
+  git commit -m "feat(seed): upload shared placeholder image to listing-images bucket"
+  ```
+
+---
+
+## Task 6: seedListings Function
+
+**Files:**
+- Modify: `scripts/seed-staging.ts`
+
+- [ ] **Step 1: Add listing service imports**
+
+  Add these imports at the top of the file:
+
+  ```typescript
+  import {
+    createListing,
+    upsertItemDetails,
+    upsertServiceDetails,
+    publishListing,
+  } from "../apps/backend/src/services/listings.js";
+  import { getCategories, getTags } from "../apps/backend/src/services/categories.js";
+  ```
+
+- [ ] **Step 2: Add the `seedListings` function**
+
+  Add this function before `main()`:
+
+  ```typescript
+  // ─── Seed listings ─────────────────────────────────────────────────────────────
+  // Creates ~25 active listings spread across 5 sellers.
+  // Each listing gets: details (item/service), one placeholder image, tags, then published.
+
+  type ItemCondition = "new" | "like_new" | "good" | "fair" | "poor";
+
+  type ListingDef = {
+    seller: string;
+    title: string;
+    description: string;
+    type: "item" | "service";
+    category: string;
+    price: number;
+    location: string;
+    tags: string[];
+    item?: { condition: ItemCondition; quantity: number };
+    service?: { duration_minutes: number; price_unit: string };
+  };
+
+  const LISTINGS: ListingDef[] = [
+    // ── Alex: Textbooks + Electronics ────────────────────────────────────────────
+    { seller: "demo.alex@demo.edu", title: "CHEM 101 Textbook", description: "Zumdahl Chemistry 10th ed. A few highlights inside.", type: "item", category: "Textbooks", price: 35, location: "North Campus", tags: ["negotiable", "pickup-only"], item: { condition: "good", quantity: 1 } },
+    { seller: "demo.alex@demo.edu", title: "Calculus: Early Transcendentals", description: "Stewart 9th edition, no writing inside.", type: "item", category: "Textbooks", price: 50, location: "North Campus", tags: ["like-new"], item: { condition: "like_new", quantity: 1 } },
+    { seller: "demo.alex@demo.edu", title: "TI-84 Plus CE Calculator", description: "Used one semester, works perfectly.", type: "item", category: "Electronics", price: 80, location: "Library", tags: ["negotiable"], item: { condition: "good", quantity: 1 } },
+    { seller: "demo.alex@demo.edu", title: "USB-C Laptop Stand", description: "Adjustable aluminum stand, lightly used.", type: "item", category: "Electronics", price: 20, location: "Library", tags: ["pickup-only"], item: { condition: "like_new", quantity: 1 } },
+    { seller: "demo.alex@demo.edu", title: "Wireless Noise-Cancelling Headphones", description: "Sony WH-1000XM4. Great battery life, minor scratches on headband.", type: "item", category: "Electronics", price: 120, location: "North Campus", tags: ["OBO"], item: { condition: "good", quantity: 1 } },
+    // ── Sam: Textbooks + Clothing ─────────────────────────────────────────────────
+    { seller: "demo.sam@demo.edu", title: "BIO 201 Lab Manual", description: "Clean copy, all pages intact.", type: "item", category: "Textbooks", price: 15, location: "South Dorms", tags: ["semester-end-sale", "negotiable"], item: { condition: "fair", quantity: 1 } },
+    { seller: "demo.sam@demo.edu", title: "Intro to Psychology (Myers)", description: "Highlights only in first 3 chapters.", type: "item", category: "Textbooks", price: 25, location: "South Dorms", tags: ["negotiable", "OBO"], item: { condition: "good", quantity: 1 } },
+    { seller: "demo.sam@demo.edu", title: "North Face Rain Jacket — Size M", description: "Waterproof, worn twice. Dark blue.", type: "item", category: "Clothing", price: 65, location: "South Dorms", tags: ["like-new", "negotiable"], item: { condition: "like_new", quantity: 1 } },
+    { seller: "demo.sam@demo.edu", title: "Campus Hoodie — Size L", description: "University hoodie, washed once.", type: "item", category: "Clothing", price: 20, location: "South Dorms", tags: ["semester-end-sale"], item: { condition: "good", quantity: 1 } },
+    { seller: "demo.sam@demo.edu", title: "Running Shoes — Size 10", description: "Nike Pegasus, 3 months old. Light use.", type: "item", category: "Clothing", price: 45, location: "South Dorms", tags: ["negotiable"], item: { condition: "good", quantity: 1 } },
+    // ── Jordan: Services + Electronics ───────────────────────────────────────────
+    { seller: "demo.jordan@demo.edu", title: "Python & Data Structures Tutoring", description: "CS major offering tutoring for CS101/201. $20/hr.", type: "service", category: "Services", price: 20, location: "Library", tags: [], service: { duration_minutes: 60, price_unit: "per hour" } },
+    { seller: "demo.jordan@demo.edu", title: "Resume & Cover Letter Review", description: "Career center trained, helped 20+ students get internships.", type: "service", category: "Services", price: 15, location: "Library", tags: ["delivery-available"], service: { duration_minutes: 45, price_unit: "per session" } },
+    { seller: "demo.jordan@demo.edu", title: "iPad Air (5th gen) — 64GB WiFi", description: "Space Gray, barely used, comes with Apple Pencil case.", type: "item", category: "Electronics", price: 350, location: "East Quad", tags: ["negotiable"], item: { condition: "like_new", quantity: 1 } },
+    { seller: "demo.jordan@demo.edu", title: "Mechanical Keyboard — TKL", description: "Keychron K2, brown switches, backlit.", type: "item", category: "Electronics", price: 60, location: "East Quad", tags: ["OBO"], item: { condition: "good", quantity: 1 } },
+    { seller: "demo.jordan@demo.edu", title: "Stats Tutoring (STAT 301/401)", description: "PhD student offering stats help. R and SPSS.", type: "service", category: "Services", price: 25, location: "Science Building", tags: [], service: { duration_minutes: 60, price_unit: "per hour" } },
+    // ── Riley (Business): Furniture + Services ────────────────────────────────────
+    { seller: "demo.riley@demo.edu", title: "Ergonomic Desk Chair", description: "Mesh back, lumbar support, adjustable armrests.", type: "item", category: "Furniture", price: 85, location: "West Campus Apts", tags: ["pickup-only", "negotiable"], item: { condition: "good", quantity: 1 } },
+    { seller: "demo.riley@demo.edu", title: "Mini Fridge — 3.2 cu ft", description: "Perfect for dorm. Runs quietly, no damage.", type: "item", category: "Furniture", price: 70, location: "West Campus Apts", tags: ["semester-end-sale", "pickup-only"], item: { condition: "good", quantity: 1 } },
+    { seller: "demo.riley@demo.edu", title: "Graphic Design & Flyer Work", description: "Design club president. Logos, event flyers, social media graphics.", type: "service", category: "Services", price: 30, location: "Art Building", tags: ["delivery-available"], service: { duration_minutes: 90, price_unit: "per project" } },
+    { seller: "demo.riley@demo.edu", title: "Bookshelf — 5 Tier", description: "IKEA Billy, white. Disassembled for easy transport.", type: "item", category: "Furniture", price: 40, location: "West Campus Apts", tags: ["pickup-only", "OBO"], item: { condition: "fair", quantity: 1 } },
+    { seller: "demo.riley@demo.edu", title: "Moving Help — End of Semester", description: "Truck + muscle. Available weekends in May.", type: "service", category: "Services", price: 50, location: "West Campus Apts", tags: ["urgent"], service: { duration_minutes: 120, price_unit: "per hour" } },
+    // ── Casey: Sports + Free Stuff ────────────────────────────────────────────────
+    { seller: "demo.casey@demo.edu", title: "Road Bike — 54cm Frame", description: "Trek FX3, 21-speed, replaced tires last semester.", type: "item", category: "Transportation", price: 250, location: "Bike Racks — Rec Center", tags: ["negotiable"], item: { condition: "good", quantity: 1 } },
+    { seller: "demo.casey@demo.edu", title: "Yoga Mat + Blocks Set", description: "Lululemon mat, barely used. Includes two cork blocks.", type: "item", category: "Sports & Fitness", price: 40, location: "Rec Center", tags: ["like-new"], item: { condition: "like_new", quantity: 1 } },
+    { seller: "demo.casey@demo.edu", title: "Adjustable Dumbbell Set (5–25 lb)", description: "Bowflex SelectTech, great condition.", type: "item", category: "Sports & Fitness", price: 150, location: "South Dorms", tags: ["OBO", "pickup-only"], item: { condition: "good", quantity: 1 } },
+    { seller: "demo.casey@demo.edu", title: "FREE: Moving Boxes (10 pack)", description: "Large and medium sizes. Clean and ready to use.", type: "item", category: "Free Stuff", price: 0, location: "South Dorms", tags: ["pickup-only", "urgent"], item: { condition: "good", quantity: 10 } },
+    { seller: "demo.casey@demo.edu", title: "FREE: Desk Lamp", description: "LED desk lamp, works perfectly, no longer needed.", type: "item", category: "Free Stuff", price: 0, location: "South Dorms", tags: ["pickup-only"], item: { condition: "good", quantity: 1 } },
+  ];
+
+  async function seedListings(
+    userMap: Map<string, string>,
+    categoryMap: Map<string, string>,
+    tagMap: Map<string, string>,
+  ): Promise<number> {
+    let count = 0;
+
+    for (const def of LISTINGS) {
+      const userId = userMap.get(def.seller);
+      const categoryId = categoryMap.get(def.category);
+      if (!userId) throw new Error(`User not found for seller: ${def.seller}`);
+      if (!categoryId) throw new Error(`Category not found: "${def.category}"`);
+
+      const listing = await createListing({
+        user_id: userId,
+        type: def.type,
+        title: def.title,
+        description: def.description,
+        price: def.price,
+        category_id: categoryId,
+        location: def.location,
+      });
+
+      if (def.type === "item" && def.item) {
+        await upsertItemDetails(listing.id, userId, {
+          condition: def.item.condition,
+          quantity: def.item.quantity,
+        });
+      }
+
+      if (def.type === "service" && def.service) {
+        await upsertServiceDetails(listing.id, userId, {
+          duration_minutes: def.service.duration_minutes,
+          price_unit: def.service.price_unit,
+          available_from: null,
+          available_to: null,
+        });
+      }
+
+      // Insert placeholder image row directly — reuses the one uploaded in uploadPlaceholder().
+      const { error: imgError } = await supabase.from("listing_images").insert({
+        listing_id: listing.id,
+        path: PLACEHOLDER_STORAGE_PATH,
+        alt_text: "Demo listing image",
+        order_no: 0,
+      });
+      if (imgError) throw new Error(`Failed to insert image for "${def.title}": ${imgError.message}`);
+
+      // Attach tags by name lookup — skips unknown tag names gracefully.
+      for (const tagName of def.tags) {
+        const tagId = tagMap.get(tagName);
+        if (!tagId) continue;
+        const { error: tagError } = await supabase.from("listing_tags").insert({
+          listing_id: listing.id,
+          tag_id: tagId,
+        });
+        if (tagError) throw new Error(`Failed to attach tag "${tagName}" to "${def.title}": ${tagError.message}`);
+      }
+
+      // publishListing validates readiness and sets status → active.
+      await publishListing(listing.id, userId);
+      console.log(`  Created: ${def.title}`);
+      count++;
+    }
+
+    return count;
+  }
+  ```
+
+- [ ] **Step 3: Wire `seedListings` into `main()`**
+
+  Replace the partial `main()` with the complete final version:
+
+  ```typescript
+  async function main(): Promise<void> {
+    checkNotProduction();
+
+    console.log("\nCampus Marketplace — Staging Seed Script");
+    console.log("─────────────────────────────────────────");
+    console.log(`Targeting: ${process.env.SUPABASE_URL}`);
+    console.log("\nThis will:");
+    console.log("  • Delete demo accounts (demo.alex/sam/jordan/riley/casey @demo.edu) + all their listings");
+    console.log("  • Create 5 fresh demo accounts with ~25 listings\n");
+
+    const rl = readline.createInterface({ input: stdin, output: stdout });
+    const answer = await rl.question("Proceed? (y/n) ");
+    rl.close();
+
+    if (answer.toLowerCase() !== "y") {
+      console.log("Aborted.");
+      process.exit(0);
+    }
+
+    console.log("\n[1/4] Wiping demo accounts...");
+    const wiped = await wipeDemo();
+    console.log(`  Deleted ${wiped} existing demo account(s)`);
+
+    console.log("\n[2/4] Uploading placeholder image...");
+    await uploadPlaceholder();
+    console.log(`  Uploaded ${PLACEHOLDER_STORAGE_PATH}`);
+
+    console.log("\n[3/4] Creating demo users...");
+    const userMap = await seedUsers();
+
+    console.log("\n[4/4] Creating listings...");
+    const [categories, tags] = await Promise.all([getCategories(), getTags()]);
+    const categoryMap = new Map(categories.map((c) => [c.name, c.id]));
+    const tagMap = new Map(tags.map((t) => [t.name, t.id]));
+    const listingCount = await seedListings(userMap, categoryMap, tagMap);
+
+    console.log("\n─────────────────────────────────────────");
+    console.log(`Wiped   ${wiped} demo account(s)`);
+    console.log(`Created 5 users`);
+    console.log(`Created ${listingCount} listings`);
+    console.log("\nDone. Run 'npm run dev' to browse the seeded marketplace.");
+  }
+  ```
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add scripts/seed-staging.ts
+  git commit -m "feat(seed): add seedListings — 25 demo listings across 5 sellers"
+  ```
+
+---
+
+## Task 7: End-to-End Verification
+
+- [ ] **Step 1: Run the full seed script**
+
+  ```bash
+  npm run seed
+  ```
+
+  Expected final output:
+  ```
+  [1/4] Wiping demo accounts...
+    Deleted 0 existing demo account(s)
+  [2/4] Uploading placeholder image...
+    Uploaded seed/placeholder.png
+  [3/4] Creating demo users...
+    Created: demo.alex@demo.edu
+    Created: demo.sam@demo.edu
+    Created: demo.jordan@demo.edu
+    Created: demo.riley@demo.edu
+    Created: demo.casey@demo.edu
+  [4/4] Creating listings...
+    Created: CHEM 101 Textbook
+    ... (25 lines total)
+    Created: FREE: Desk Lamp
+  ─────────────────────────────────────────
+  Wiped   0 demo account(s)
+  Created 5 users
+  Created 25 listings
+
+  Done. Run 'npm run dev' to browse the seeded marketplace.
+  ```
+
+  If any step errors, read the error message — it will name the exact listing or user that failed.
+
+- [ ] **Step 2: Start the dev server and verify in browser**
+
+  ```bash
+  npm run dev
+  ```
+
+  Open `http://localhost:5173`. Check:
+  - Homepage shows listing cards — confirm images appear (grey placeholder boxes, not broken icons)
+  - Browse by category — Textbooks, Electronics, Services all have listings
+  - Open a listing detail page — confirm image, price, condition/duration render correctly
+
+- [ ] **Step 3: Verify idempotency — run the seed script a second time**
+
+  ```bash
+  npm run seed
+  ```
+
+  Expected: `Wiped 5 demo account(s)` then re-creates everything. Final listing count still 25. No errors.
+
+- [ ] **Step 4: Copy plan file to project docs**
+
+  ```bash
+  cp C:/Users/alexe/.claude/plans/wiggly-bubbling-cake.md docs/superpowers/plans/2026-04-15-seed-data.md
+  ```
+
+  ```bash
+  git add docs/superpowers/plans/2026-04-15-seed-data.md
+  git commit -m "docs: add seed data implementation plan"
+  ```
+
+- [ ] **Step 5: Final commit — mark CM-US-050 complete**
+
+  ```bash
+  git add -A
+  git commit -m "feat(seed): complete CM-US-050 — staging demo seed script with 5 users + 25 listings"
+  ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "apps/backend"
       ],
       "devDependencies": {
-        "supabase": "^1.199.0"
+        "supabase": "^1.199.0",
+        "tsx": "^4.19.2"
       },
       "engines": {
         "node": "22.x",
@@ -3749,6 +3750,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -4962,6 +4976,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.9",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.9.tgz",
@@ -5480,6 +5504,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "setup": "npm install && npm run build --workspace=apps/backend && npm run dev",
     "setup:windows": "powershell -ExecutionPolicy Bypass -File dev.ps1",
     "setup:unix": "bash dev.sh",
-    "seed": "node --env-file=apps/backend/.env.local --import tsx/esm scripts/seed-staging.ts"
+    "seed": "node --env-file=apps/backend/.env.local --import tsx scripts/seed-staging.ts"
   },
   "devDependencies": {
     "supabase": "^1.199.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "setup": "npm install && npm run build --workspace=apps/backend && npm run dev",
     "setup:windows": "powershell -ExecutionPolicy Bypass -File dev.ps1",
     "setup:unix": "bash dev.sh",
-    "seed": "node --env-file=apps/backend/.env.local --import tsx scripts/seed-staging.ts"
+    "seed": "node --env-file=apps/backend/.env.local --import tsx scripts/seed-staging.ts",
+    "seed:wipe": "node --env-file=apps/backend/.env.local --import tsx scripts/seed-staging.ts -- --wipe-only"
   },
   "devDependencies": {
     "supabase": "^1.199.0",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
     "test:coverage": "npm run test:coverage --workspace=apps/backend",
     "setup": "npm install && npm run build --workspace=apps/backend && npm run dev",
     "setup:windows": "powershell -ExecutionPolicy Bypass -File dev.ps1",
-    "setup:unix": "bash dev.sh"
+    "setup:unix": "bash dev.sh",
+    "seed": "node --env-file=apps/backend/.env.local --import tsx/esm scripts/seed-staging.ts"
   },
   "devDependencies": {
-    "supabase": "^1.199.0"
+    "supabase": "^1.199.0",
+    "tsx": "^4.19.2"
   },
   "engines": {
     "node": "22.x",

--- a/scripts/seed-staging.ts
+++ b/scripts/seed-staging.ts
@@ -25,11 +25,6 @@ const DEMO_ACCOUNTS = [
   { email: "demo.casey@demo.edu",  password: "demo1234", displayName: "Casey (Demo)",  accountType: "student"  as const },
 ];
 
-// Minimal 1×1 grey PNG, base64-encoded — no external file or downloads needed.
-const PLACEHOLDER_PNG = Buffer.from(
-  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQI12NgAAAAAgAB4iG8MwAAAABJRU5ErkJggg==",
-  "base64",
-);
 const PLACEHOLDER_STORAGE_PATH = "seed/placeholder.png";
 
 // ─── Safety check ─────────────────────────────────────────────────────────────
@@ -79,9 +74,14 @@ async function wipeDemo(): Promise<number> {
 // All seed listings share this path — avoids 25 separate uploads.
 
 async function uploadPlaceholder(): Promise<void> {
+  // Fetch a real placeholder image so listing cards don't render as black squares.
+  const response = await fetch("https://placehold.co/600x400/e2e8f0/94a3b8.png");
+  if (!response.ok) throw new Error(`Failed to fetch placeholder image: ${response.statusText}`);
+  const buffer = Buffer.from(await response.arrayBuffer());
+
   const { error } = await supabase.storage
     .from("listing-images")
-    .upload(PLACEHOLDER_STORAGE_PATH, PLACEHOLDER_PNG, {
+    .upload(PLACEHOLDER_STORAGE_PATH, buffer, {
       contentType: "image/png",
       upsert: true,
     });

--- a/scripts/seed-staging.ts
+++ b/scripts/seed-staging.ts
@@ -1,0 +1,13 @@
+// scripts/seed-staging.ts
+// Staging seed script — wipes and re-creates demo accounts + listings.
+// Run: npm run seed
+// NEVER run against production.
+
+async function main(): Promise<void> {
+  console.log("Seed script placeholder — tasks to be implemented.");
+}
+
+main().catch((err) => {
+  console.error("Seed failed:", err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/scripts/seed-staging.ts
+++ b/scripts/seed-staging.ts
@@ -25,7 +25,8 @@ const DEMO_ACCOUNTS = [
   { email: "demo.casey@demo.edu",  password: "demo1234", displayName: "Casey (Demo)",  accountType: "student"  as const },
 ];
 
-const PLACEHOLDER_STORAGE_PATH = "seed/placeholder.png";
+// Versioned path — bump the suffix whenever the placeholder changes to bust CDN cache.
+const PLACEHOLDER_STORAGE_PATH = "seed/placeholder-v3.png";
 
 // ─── Safety check ─────────────────────────────────────────────────────────────
 // Set SUPABASE_PROD_REF in your shell (not committed) to match your production
@@ -249,12 +250,17 @@ async function seedListings(
 async function main(): Promise<void> {
   checkNotProduction();
 
+  const wipeOnly = process.argv.includes("--wipe-only");
+
   console.log("\nCampus Marketplace — Staging Seed Script");
   console.log("─────────────────────────────────────────");
   console.log(`Targeting: ${process.env.SUPABASE_URL}`);
   console.log("\nThis will:");
   console.log("  • Delete demo accounts (demo.alex/sam/jordan/riley/casey @demo.edu) + all their listings");
-  console.log("  • Create 5 fresh demo accounts with ~25 listings\n");
+  if (!wipeOnly) {
+    console.log("  • Create 5 fresh demo accounts with ~25 listings");
+  }
+  console.log();
 
   const rl = readline.createInterface({ input: stdin, output: stdout });
   const answer = await rl.question("Proceed? (y/n) ");
@@ -265,9 +271,15 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  console.log("\n[1/4] Wiping demo accounts...");
+  console.log("\n[1/1] Wiping demo accounts...");
   const wiped = await wipeDemo();
   console.log(`  Deleted ${wiped} existing demo account(s)`);
+
+  if (wipeOnly) {
+    console.log("\n─────────────────────────────────────────");
+    console.log(`Wiped ${wiped} demo account(s). Done.`);
+    return;
+  }
 
   console.log("\n[2/4] Uploading placeholder image...");
   await uploadPlaceholder();

--- a/scripts/seed-staging.ts
+++ b/scripts/seed-staging.ts
@@ -3,11 +3,55 @@
 // Run: npm run seed
 // NEVER run against production.
 
+import * as readline from "node:readline/promises";
+import { stdin, stdout } from "node:process";
+
+// ─── Safety check ─────────────────────────────────────────────────────────────
+// Set SUPABASE_PROD_REF in your shell (not committed) to match your production
+// Supabase project ref string (e.g. "abcxyzproject123"). The script exits if
+// the staging URL contains it.
+
+function checkNotProduction(): void {
+  const url = process.env.SUPABASE_URL ?? "";
+  const env = process.env.NODE_ENV ?? "";
+  const prodRef = process.env.SUPABASE_PROD_REF ?? "";
+
+  if (env === "production") {
+    console.error("ERROR: NODE_ENV=production — refusing to seed.");
+    process.exit(1);
+  }
+  if (prodRef && url.includes(prodRef)) {
+    console.error("ERROR: SUPABASE_URL matches SUPABASE_PROD_REF — refusing to seed.");
+    console.error(`  URL: ${url}`);
+    process.exit(1);
+  }
+}
+
+// ─── Main ──────────────────────────────────────────────────────────────────────
+
 async function main(): Promise<void> {
-  console.log("Seed script placeholder — tasks to be implemented.");
+  checkNotProduction();
+
+  console.log("\nCampus Marketplace — Staging Seed Script");
+  console.log("─────────────────────────────────────────");
+  console.log(`Targeting: ${process.env.SUPABASE_URL}`);
+  console.log("\nThis will:");
+  console.log("  • Delete demo accounts (demo.alex/sam/jordan/riley/casey @demo.edu) + all their listings");
+  console.log("  • Create 5 fresh demo accounts with ~25 listings\n");
+
+  const rl = readline.createInterface({ input: stdin, output: stdout });
+  const answer = await rl.question("Proceed? (y/n) ");
+  rl.close();
+
+  if (answer.toLowerCase() !== "y") {
+    console.log("Aborted.");
+    process.exit(0);
+  }
+
+  console.log("\nNothing seeded yet — more tasks to implement.");
 }
 
 main().catch((err) => {
-  console.error("Seed failed:", err instanceof Error ? err.message : err);
+  console.error("\nSeed failed:", err instanceof Error ? err.message : err);
   process.exit(1);
 });

--- a/scripts/seed-staging.ts
+++ b/scripts/seed-staging.ts
@@ -25,8 +25,18 @@ const DEMO_ACCOUNTS = [
   { email: "demo.casey@demo.edu",  password: "demo1234", displayName: "Casey (Demo)",  accountType: "student"  as const },
 ];
 
-// Versioned path — bump the suffix whenever the placeholder changes to bust CDN cache.
-const PLACEHOLDER_STORAGE_PATH = "seed/placeholder-v3.png";
+// One real photo per category, fetched from Lorem Picsum (seeded = same image every run).
+// Storage paths are stable so re-seeding overwrites rather than accumulating files.
+const CATEGORY_IMAGES: Record<string, { storagePath: string; picsumSeed: string }> = {
+  "Textbooks":       { storagePath: "seed/cat-textbooks.jpg",    picsumSeed: "books42"    },
+  "Electronics":     { storagePath: "seed/cat-electronics.jpg",  picsumSeed: "tech77"     },
+  "Furniture":       { storagePath: "seed/cat-furniture.jpg",    picsumSeed: "room19"     },
+  "Clothing":        { storagePath: "seed/cat-clothing.jpg",     picsumSeed: "fashion55"  },
+  "Services":        { storagePath: "seed/cat-services.jpg",     picsumSeed: "people88"   },
+  "Transportation":  { storagePath: "seed/cat-transport.jpg",    picsumSeed: "bike33"     },
+  "Sports & Fitness":{ storagePath: "seed/cat-sports.jpg",       picsumSeed: "sport64"    },
+  "Free Stuff":      { storagePath: "seed/cat-freestuff.jpg",    picsumSeed: "gift11"     },
+};
 
 // ─── Safety check ─────────────────────────────────────────────────────────────
 // Set SUPABASE_PROD_REF in your shell (not committed) to match your production
@@ -117,23 +127,23 @@ async function wipeDemoListings(userMap: Map<string, string>): Promise<number> {
   return count ?? 0;
 }
 
-// ─── Upload placeholder image ──────────────────────────────────────────────────
-// Uploads a single 1×1 PNG to the listing-images bucket.
-// All seed listings share this path — avoids 25 separate uploads.
+// ─── Upload category images ────────────────────────────────────────────────────
+// Fetches one real photo per category from Lorem Picsum and uploads to storage.
+// Seeded URLs return the same photo every run, so re-seeding is stable.
 
-async function uploadPlaceholder(): Promise<void> {
-  // Fetch a real placeholder image so listing cards don't render as black squares.
-  const response = await fetch("https://placehold.co/600x400/e2e8f0/94a3b8.png");
-  if (!response.ok) throw new Error(`Failed to fetch placeholder image: ${response.statusText}`);
-  const buffer = Buffer.from(await response.arrayBuffer());
+async function uploadCategoryImages(): Promise<void> {
+  for (const [category, { storagePath, picsumSeed }] of Object.entries(CATEGORY_IMAGES)) {
+    const url = `https://picsum.photos/seed/${picsumSeed}/600/400`;
+    const response = await fetch(url);
+    if (!response.ok) throw new Error(`Failed to fetch image for "${category}": ${response.statusText}`);
+    const buffer = Buffer.from(await response.arrayBuffer());
 
-  const { error } = await supabase.storage
-    .from("listing-images")
-    .upload(PLACEHOLDER_STORAGE_PATH, buffer, {
-      contentType: "image/png",
-      upsert: true,
-    });
-  if (error) throw new Error(`Failed to upload placeholder: ${error.message}`);
+    const { error } = await supabase.storage
+      .from("listing-images")
+      .upload(storagePath, buffer, { contentType: "image/jpeg", upsert: true });
+    if (error) throw new Error(`Failed to upload image for "${category}": ${error.message}`);
+    console.log(`  Uploaded: ${storagePath}`);
+  }
 }
 
 
@@ -230,11 +240,12 @@ async function seedListings(
       });
     }
 
-    // Insert placeholder image row directly — reuses the one uploaded in uploadPlaceholder().
+    // Insert category-specific image — each category has its own real photo.
+    const imagePath = CATEGORY_IMAGES[def.category]?.storagePath ?? "seed/cat-freestuff.jpg";
     const { error: imgError } = await supabase.from("listing_images").insert({
       listing_id: listing.id,
-      path: PLACEHOLDER_STORAGE_PATH,
-      alt_text: "Demo listing image",
+      path: imagePath,
+      alt_text: `${def.category} listing image`,
       order_no: 0,
     });
     if (imgError) throw new Error(`Failed to insert image for "${def.title}": ${imgError.message}`);
@@ -301,8 +312,8 @@ async function main(): Promise<void> {
   }
 
   console.log("\n[3/3] Seeding listings...");
-  await uploadPlaceholder();
-  console.log(`  Uploaded ${PLACEHOLDER_STORAGE_PATH}`);
+  console.log("  Uploading category images...");
+  await uploadCategoryImages();
 
   const [categories, tags] = await Promise.all([getCategories(), getTags()]);
   const categoryMap = new Map(categories.map((c) => [c.name, c.id]));

--- a/scripts/seed-staging.ts
+++ b/scripts/seed-staging.ts
@@ -5,6 +5,32 @@
 
 import * as readline from "node:readline/promises";
 import { stdin, stdout } from "node:process";
+import { supabase } from "../apps/backend/src/supabase-client.js";
+import { upsertProfile } from "../apps/backend/src/services/profile.js";
+import {
+  createListing,
+  upsertItemDetails,
+  upsertServiceDetails,
+  publishListing,
+} from "../apps/backend/src/services/listings.js";
+import { getCategories, getTags } from "../apps/backend/src/services/categories.js";
+
+// ─── Demo account definitions ─────────────────────────────────────────────────
+
+const DEMO_ACCOUNTS = [
+  { email: "demo.alex@demo.edu",   password: "demo1234", displayName: "Alex (Demo)",   accountType: "student"  as const },
+  { email: "demo.sam@demo.edu",    password: "demo1234", displayName: "Sam (Demo)",    accountType: "student"  as const },
+  { email: "demo.jordan@demo.edu", password: "demo1234", displayName: "Jordan (Demo)", accountType: "student"  as const },
+  { email: "demo.riley@demo.edu",  password: "demo1234", displayName: "Riley (Demo)",  accountType: "business" as const },
+  { email: "demo.casey@demo.edu",  password: "demo1234", displayName: "Casey (Demo)",  accountType: "student"  as const },
+];
+
+// Minimal 1×1 grey PNG, base64-encoded — no external file or downloads needed.
+const PLACEHOLDER_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQI12NgAAAAAgAB4iG8MwAAAABJRU5ErkJggg==",
+  "base64",
+);
+const PLACEHOLDER_STORAGE_PATH = "seed/placeholder.png";
 
 // ─── Safety check ─────────────────────────────────────────────────────────────
 // Set SUPABASE_PROD_REF in your shell (not committed) to match your production
@@ -25,6 +51,197 @@ function checkNotProduction(): void {
     console.error(`  URL: ${url}`);
     process.exit(1);
   }
+}
+
+// ─── Wipe demo accounts ────────────────────────────────────────────────────────
+// Finds each demo email in auth.users and deletes it.
+// Cascade: profiles, listings, listing_images, item_details, service_details, listing_tags.
+
+async function wipeDemo(): Promise<number> {
+  const targetEmails = new Set(DEMO_ACCOUNTS.map((a) => a.email));
+  let wiped = 0;
+
+  const { data, error } = await supabase.auth.admin.listUsers({ perPage: 1000 });
+  if (error) throw new Error(`Failed to list users: ${error.message}`);
+
+  for (const user of data.users) {
+    if (user.email && targetEmails.has(user.email)) {
+      const { error: deleteError } = await supabase.auth.admin.deleteUser(user.id);
+      if (deleteError) throw new Error(`Failed to delete ${user.email}: ${deleteError.message}`);
+      wiped++;
+    }
+  }
+  return wiped;
+}
+
+// ─── Upload placeholder image ──────────────────────────────────────────────────
+// Uploads a single 1×1 PNG to the listing-images bucket.
+// All seed listings share this path — avoids 25 separate uploads.
+
+async function uploadPlaceholder(): Promise<void> {
+  const { error } = await supabase.storage
+    .from("listing-images")
+    .upload(PLACEHOLDER_STORAGE_PATH, PLACEHOLDER_PNG, {
+      contentType: "image/png",
+      upsert: true,
+    });
+  if (error) throw new Error(`Failed to upload placeholder: ${error.message}`);
+}
+
+// ─── Seed users ────────────────────────────────────────────────────────────────
+// Creates 5 demo accounts via admin API (no email verification needed).
+// Returns a map of email → Supabase user UUID for use in listing creation.
+
+async function seedUsers(): Promise<Map<string, string>> {
+  const userMap = new Map<string, string>();
+
+  for (const account of DEMO_ACCOUNTS) {
+    const { data, error } = await supabase.auth.admin.createUser({
+      email: account.email,
+      password: account.password,
+      email_confirm: true,
+      user_metadata: {
+        display_name: account.displayName,
+        account_type: account.accountType,
+      },
+    });
+
+    if (error || !data.user) {
+      throw new Error(`Failed to create ${account.email}: ${error?.message ?? "unknown"}`);
+    }
+
+    await upsertProfile({
+      user_id: data.user.id,
+      display_name: account.displayName,
+      account_type: account.accountType,
+    });
+
+    userMap.set(account.email, data.user.id);
+    console.log(`  Created: ${account.email}`);
+  }
+  return userMap;
+}
+
+// ─── Listing definitions ──────────────────────────────────────────────────────
+
+type ItemCondition = "new" | "like_new" | "good" | "fair" | "poor";
+
+type ListingDef = {
+  seller: string;
+  title: string;
+  description: string;
+  type: "item" | "service";
+  category: string;
+  price: number;
+  location: string;
+  tags: string[];
+  item?: { condition: ItemCondition; quantity: number };
+  service?: { duration_minutes: number; price_unit: string };
+};
+
+const LISTINGS: ListingDef[] = [
+  // ── Alex: Textbooks + Electronics ────────────────────────────────────────────
+  { seller: "demo.alex@demo.edu", title: "CHEM 101 Textbook", description: "Zumdahl Chemistry 10th ed. A few highlights inside.", type: "item", category: "Textbooks", price: 35, location: "North Campus", tags: ["negotiable", "pickup-only"], item: { condition: "good", quantity: 1 } },
+  { seller: "demo.alex@demo.edu", title: "Calculus: Early Transcendentals", description: "Stewart 9th edition, no writing inside.", type: "item", category: "Textbooks", price: 50, location: "North Campus", tags: ["like-new"], item: { condition: "like_new", quantity: 1 } },
+  { seller: "demo.alex@demo.edu", title: "TI-84 Plus CE Calculator", description: "Used one semester, works perfectly.", type: "item", category: "Electronics", price: 80, location: "Library", tags: ["negotiable"], item: { condition: "good", quantity: 1 } },
+  { seller: "demo.alex@demo.edu", title: "USB-C Laptop Stand", description: "Adjustable aluminum stand, lightly used.", type: "item", category: "Electronics", price: 20, location: "Library", tags: ["pickup-only"], item: { condition: "like_new", quantity: 1 } },
+  { seller: "demo.alex@demo.edu", title: "Wireless Noise-Cancelling Headphones", description: "Sony WH-1000XM4. Great battery life, minor scratches on headband.", type: "item", category: "Electronics", price: 120, location: "North Campus", tags: ["OBO"], item: { condition: "good", quantity: 1 } },
+  // ── Sam: Textbooks + Clothing ─────────────────────────────────────────────────
+  { seller: "demo.sam@demo.edu", title: "BIO 201 Lab Manual", description: "Clean copy, all pages intact.", type: "item", category: "Textbooks", price: 15, location: "South Dorms", tags: ["semester-end-sale", "negotiable"], item: { condition: "fair", quantity: 1 } },
+  { seller: "demo.sam@demo.edu", title: "Intro to Psychology (Myers)", description: "Highlights only in first 3 chapters.", type: "item", category: "Textbooks", price: 25, location: "South Dorms", tags: ["negotiable", "OBO"], item: { condition: "good", quantity: 1 } },
+  { seller: "demo.sam@demo.edu", title: "North Face Rain Jacket — Size M", description: "Waterproof, worn twice. Dark blue.", type: "item", category: "Clothing", price: 65, location: "South Dorms", tags: ["like-new", "negotiable"], item: { condition: "like_new", quantity: 1 } },
+  { seller: "demo.sam@demo.edu", title: "Campus Hoodie — Size L", description: "University hoodie, washed once.", type: "item", category: "Clothing", price: 20, location: "South Dorms", tags: ["semester-end-sale"], item: { condition: "good", quantity: 1 } },
+  { seller: "demo.sam@demo.edu", title: "Running Shoes — Size 10", description: "Nike Pegasus, 3 months old. Light use.", type: "item", category: "Clothing", price: 45, location: "South Dorms", tags: ["negotiable"], item: { condition: "good", quantity: 1 } },
+  // ── Jordan: Services + Electronics ───────────────────────────────────────────
+  { seller: "demo.jordan@demo.edu", title: "Python & Data Structures Tutoring", description: "CS major offering tutoring for CS101/201. $20/hr.", type: "service", category: "Services", price: 20, location: "Library", tags: [], service: { duration_minutes: 60, price_unit: "per hour" } },
+  { seller: "demo.jordan@demo.edu", title: "Resume & Cover Letter Review", description: "Career center trained, helped 20+ students get internships.", type: "service", category: "Services", price: 15, location: "Library", tags: ["delivery-available"], service: { duration_minutes: 45, price_unit: "per session" } },
+  { seller: "demo.jordan@demo.edu", title: "iPad Air (5th gen) — 64GB WiFi", description: "Space Gray, barely used, comes with Apple Pencil case.", type: "item", category: "Electronics", price: 350, location: "East Quad", tags: ["negotiable"], item: { condition: "like_new", quantity: 1 } },
+  { seller: "demo.jordan@demo.edu", title: "Mechanical Keyboard — TKL", description: "Keychron K2, brown switches, backlit.", type: "item", category: "Electronics", price: 60, location: "East Quad", tags: ["OBO"], item: { condition: "good", quantity: 1 } },
+  { seller: "demo.jordan@demo.edu", title: "Stats Tutoring (STAT 301/401)", description: "PhD student offering stats help. R and SPSS.", type: "service", category: "Services", price: 25, location: "Science Building", tags: [], service: { duration_minutes: 60, price_unit: "per hour" } },
+  // ── Riley (Business): Furniture + Services ────────────────────────────────────
+  { seller: "demo.riley@demo.edu", title: "Ergonomic Desk Chair", description: "Mesh back, lumbar support, adjustable armrests.", type: "item", category: "Furniture", price: 85, location: "West Campus Apts", tags: ["pickup-only", "negotiable"], item: { condition: "good", quantity: 1 } },
+  { seller: "demo.riley@demo.edu", title: "Mini Fridge — 3.2 cu ft", description: "Perfect for dorm. Runs quietly, no damage.", type: "item", category: "Furniture", price: 70, location: "West Campus Apts", tags: ["semester-end-sale", "pickup-only"], item: { condition: "good", quantity: 1 } },
+  { seller: "demo.riley@demo.edu", title: "Graphic Design & Flyer Work", description: "Design club president. Logos, event flyers, social media graphics.", type: "service", category: "Services", price: 30, location: "Art Building", tags: ["delivery-available"], service: { duration_minutes: 90, price_unit: "per project" } },
+  { seller: "demo.riley@demo.edu", title: "Bookshelf — 5 Tier", description: "IKEA Billy, white. Disassembled for easy transport.", type: "item", category: "Furniture", price: 40, location: "West Campus Apts", tags: ["pickup-only", "OBO"], item: { condition: "fair", quantity: 1 } },
+  { seller: "demo.riley@demo.edu", title: "Moving Help — End of Semester", description: "Truck + muscle. Available weekends in May.", type: "service", category: "Services", price: 50, location: "West Campus Apts", tags: ["urgent"], service: { duration_minutes: 120, price_unit: "per hour" } },
+  // ── Casey: Sports + Free Stuff ────────────────────────────────────────────────
+  { seller: "demo.casey@demo.edu", title: "Road Bike — 54cm Frame", description: "Trek FX3, 21-speed, replaced tires last semester.", type: "item", category: "Transportation", price: 250, location: "Bike Racks — Rec Center", tags: ["negotiable"], item: { condition: "good", quantity: 1 } },
+  { seller: "demo.casey@demo.edu", title: "Yoga Mat + Blocks Set", description: "Lululemon mat, barely used. Includes two cork blocks.", type: "item", category: "Sports & Fitness", price: 40, location: "Rec Center", tags: ["like-new"], item: { condition: "like_new", quantity: 1 } },
+  { seller: "demo.casey@demo.edu", title: "Adjustable Dumbbell Set (5–25 lb)", description: "Bowflex SelectTech, great condition.", type: "item", category: "Sports & Fitness", price: 150, location: "South Dorms", tags: ["OBO", "pickup-only"], item: { condition: "good", quantity: 1 } },
+  { seller: "demo.casey@demo.edu", title: "FREE: Moving Boxes (10 pack)", description: "Large and medium sizes. Clean and ready to use.", type: "item", category: "Free Stuff", price: 0, location: "South Dorms", tags: ["pickup-only", "urgent"], item: { condition: "good", quantity: 10 } },
+  { seller: "demo.casey@demo.edu", title: "FREE: Desk Lamp", description: "LED desk lamp, works perfectly, no longer needed.", type: "item", category: "Free Stuff", price: 0, location: "South Dorms", tags: ["pickup-only"], item: { condition: "good", quantity: 1 } },
+];
+
+// ─── Seed listings ─────────────────────────────────────────────────────────────
+// Creates ~25 active listings spread across 5 sellers.
+// Each listing gets: details (item/service), one placeholder image, tags, then published.
+
+async function seedListings(
+  userMap: Map<string, string>,
+  categoryMap: Map<string, string>,
+  tagMap: Map<string, string>,
+): Promise<number> {
+  let count = 0;
+
+  for (const def of LISTINGS) {
+    const userId = userMap.get(def.seller);
+    const categoryId = categoryMap.get(def.category);
+    if (!userId) throw new Error(`User not found for seller: ${def.seller}`);
+    if (!categoryId) throw new Error(`Category not found: "${def.category}"`);
+
+    const listing = await createListing({
+      user_id: userId,
+      type: def.type,
+      title: def.title,
+      description: def.description,
+      price: def.price,
+      category_id: categoryId,
+      location: def.location,
+    });
+
+    if (def.type === "item" && def.item) {
+      await upsertItemDetails(listing.id, userId, {
+        condition: def.item.condition,
+        quantity: def.item.quantity,
+      });
+    }
+
+    if (def.type === "service" && def.service) {
+      await upsertServiceDetails(listing.id, userId, {
+        duration_minutes: def.service.duration_minutes,
+        price_unit: def.service.price_unit,
+        available_from: null,
+        available_to: null,
+      });
+    }
+
+    // Insert placeholder image row directly — reuses the one uploaded in uploadPlaceholder().
+    const { error: imgError } = await supabase.from("listing_images").insert({
+      listing_id: listing.id,
+      path: PLACEHOLDER_STORAGE_PATH,
+      alt_text: "Demo listing image",
+      order_no: 0,
+    });
+    if (imgError) throw new Error(`Failed to insert image for "${def.title}": ${imgError.message}`);
+
+    // Attach tags by name lookup — skips unknown tag names gracefully.
+    for (const tagName of def.tags) {
+      const tagId = tagMap.get(tagName);
+      if (!tagId) continue;
+      const { error: tagError } = await supabase.from("listing_tags").insert({
+        listing_id: listing.id,
+        tag_id: tagId,
+      });
+      if (tagError) throw new Error(`Failed to attach tag "${tagName}" to "${def.title}": ${tagError.message}`);
+    }
+
+    // publishListing validates readiness and sets status → active.
+    await publishListing(listing.id, userId);
+    console.log(`  Created: ${def.title}`);
+    count++;
+  }
+
+  return count;
 }
 
 // ─── Main ──────────────────────────────────────────────────────────────────────
@@ -48,7 +265,28 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  console.log("\nNothing seeded yet — more tasks to implement.");
+  console.log("\n[1/4] Wiping demo accounts...");
+  const wiped = await wipeDemo();
+  console.log(`  Deleted ${wiped} existing demo account(s)`);
+
+  console.log("\n[2/4] Uploading placeholder image...");
+  await uploadPlaceholder();
+  console.log(`  Uploaded ${PLACEHOLDER_STORAGE_PATH}`);
+
+  console.log("\n[3/4] Creating demo users...");
+  const userMap = await seedUsers();
+
+  console.log("\n[4/4] Creating listings...");
+  const [categories, tags] = await Promise.all([getCategories(), getTags()]);
+  const categoryMap = new Map(categories.map((c) => [c.name, c.id]));
+  const tagMap = new Map(tags.map((t) => [t.name, t.id]));
+  const listingCount = await seedListings(userMap, categoryMap, tagMap);
+
+  console.log("\n─────────────────────────────────────────");
+  console.log(`Wiped   ${wiped} demo account(s)`);
+  console.log(`Created 5 users`);
+  console.log(`Created ${listingCount} listings`);
+  console.log("\nDone. Run 'npm run dev' to browse the seeded marketplace.");
 }
 
 main().catch((err) => {

--- a/scripts/seed-staging.ts
+++ b/scripts/seed-staging.ts
@@ -49,25 +49,72 @@ function checkNotProduction(): void {
   }
 }
 
-// ─── Wipe demo accounts ────────────────────────────────────────────────────────
-// Finds each demo email in auth.users and deletes it.
-// Cascade: profiles, listings, listing_images, item_details, service_details, listing_tags.
+// ─── Ensure demo accounts exist ───────────────────────────────────────────────
+// Creates each demo account if it doesn't already exist, otherwise reuses it.
+// Never deletes auth users — avoids Supabase auth rate limits.
+// Returns email → userId map for all 5 accounts.
 
-async function wipeDemo(): Promise<number> {
-  const targetEmails = new Set(DEMO_ACCOUNTS.map((a) => a.email));
-  let wiped = 0;
-
+async function ensureUsers(): Promise<Map<string, string>> {
   const { data, error } = await supabase.auth.admin.listUsers({ perPage: 1000 });
   if (error) throw new Error(`Failed to list users: ${error.message}`);
 
-  for (const user of data.users) {
-    if (user.email && targetEmails.has(user.email)) {
-      const { error: deleteError } = await supabase.auth.admin.deleteUser(user.id);
-      if (deleteError) throw new Error(`Failed to delete ${user.email}: ${deleteError.message}`);
-      wiped++;
+  const existingByEmail = new Map(
+    data.users
+      .filter((u) => u.email && DEMO_ACCOUNTS.some((a) => a.email === u.email))
+      .map((u) => [u.email!, u.id]),
+  );
+
+  const userMap = new Map<string, string>();
+
+  for (const account of DEMO_ACCOUNTS) {
+    const existingId = existingByEmail.get(account.email);
+
+    if (existingId) {
+      userMap.set(account.email, existingId);
+      console.log(`  Reusing: ${account.email}`);
+    } else {
+      const { data: created, error: createError } = await supabase.auth.admin.createUser({
+        email: account.email,
+        password: account.password,
+        email_confirm: true,
+        user_metadata: {
+          display_name: account.displayName,
+          account_type: account.accountType,
+        },
+      });
+      if (createError || !created.user) {
+        throw new Error(`Failed to create ${account.email}: ${createError?.message ?? "unknown"}`);
+      }
+      userMap.set(account.email, created.user.id);
+      console.log(`  Created:  ${account.email}`);
     }
+
+    await upsertProfile({
+      user_id: userMap.get(account.email)!,
+      display_name: account.displayName,
+      account_type: account.accountType,
+    });
   }
-  return wiped;
+
+  return userMap;
+}
+
+// ─── Wipe demo listings ────────────────────────────────────────────────────────
+// Hard-deletes all listings owned by demo accounts.
+// Cascades to: item_details, service_details, listing_images, listing_tags.
+// Does NOT touch auth users — accounts are kept between runs.
+
+async function wipeDemoListings(userMap: Map<string, string>): Promise<number> {
+  const userIds = [...userMap.values()];
+  if (userIds.length === 0) return 0;
+
+  const { count, error } = await supabase
+    .from("listings")
+    .delete({ count: "exact" })
+    .in("user_id", userIds);
+
+  if (error) throw new Error(`Failed to wipe demo listings: ${error.message}`);
+  return count ?? 0;
 }
 
 // ─── Upload placeholder image ──────────────────────────────────────────────────
@@ -89,39 +136,6 @@ async function uploadPlaceholder(): Promise<void> {
   if (error) throw new Error(`Failed to upload placeholder: ${error.message}`);
 }
 
-// ─── Seed users ────────────────────────────────────────────────────────────────
-// Creates 5 demo accounts via admin API (no email verification needed).
-// Returns a map of email → Supabase user UUID for use in listing creation.
-
-async function seedUsers(): Promise<Map<string, string>> {
-  const userMap = new Map<string, string>();
-
-  for (const account of DEMO_ACCOUNTS) {
-    const { data, error } = await supabase.auth.admin.createUser({
-      email: account.email,
-      password: account.password,
-      email_confirm: true,
-      user_metadata: {
-        display_name: account.displayName,
-        account_type: account.accountType,
-      },
-    });
-
-    if (error || !data.user) {
-      throw new Error(`Failed to create ${account.email}: ${error?.message ?? "unknown"}`);
-    }
-
-    await upsertProfile({
-      user_id: data.user.id,
-      display_name: account.displayName,
-      account_type: account.accountType,
-    });
-
-    userMap.set(account.email, data.user.id);
-    console.log(`  Created: ${account.email}`);
-  }
-  return userMap;
-}
 
 // ─── Listing definitions ──────────────────────────────────────────────────────
 
@@ -256,9 +270,11 @@ async function main(): Promise<void> {
   console.log("─────────────────────────────────────────");
   console.log(`Targeting: ${process.env.SUPABASE_URL}`);
   console.log("\nThis will:");
-  console.log("  • Delete demo accounts (demo.alex/sam/jordan/riley/casey @demo.edu) + all their listings");
-  if (!wipeOnly) {
-    console.log("  • Create 5 fresh demo accounts with ~25 listings");
+  console.log("  • Create demo accounts if they don't exist (accounts are kept between runs)");
+  if (wipeOnly) {
+    console.log("  • Delete all listings owned by demo accounts");
+  } else {
+    console.log("  • Delete all listings owned by demo accounts, then re-create ~25 fresh listings");
   }
   console.log();
 
@@ -271,32 +287,31 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  console.log("\n[1/1] Wiping demo accounts...");
-  const wiped = await wipeDemo();
-  console.log(`  Deleted ${wiped} existing demo account(s)`);
+  console.log("\n[1/3] Ensuring demo accounts exist...");
+  const userMap = await ensureUsers();
+
+  console.log("\n[2/3] Wiping demo listings...");
+  const wiped = await wipeDemoListings(userMap);
+  console.log(`  Deleted ${wiped} listing(s)`);
 
   if (wipeOnly) {
     console.log("\n─────────────────────────────────────────");
-    console.log(`Wiped ${wiped} demo account(s). Done.`);
+    console.log(`Wiped ${wiped} listing(s). Accounts kept. Done.`);
     return;
   }
 
-  console.log("\n[2/4] Uploading placeholder image...");
+  console.log("\n[3/3] Seeding listings...");
   await uploadPlaceholder();
   console.log(`  Uploaded ${PLACEHOLDER_STORAGE_PATH}`);
 
-  console.log("\n[3/4] Creating demo users...");
-  const userMap = await seedUsers();
-
-  console.log("\n[4/4] Creating listings...");
   const [categories, tags] = await Promise.all([getCategories(), getTags()]);
   const categoryMap = new Map(categories.map((c) => [c.name, c.id]));
   const tagMap = new Map(tags.map((t) => [t.name, t.id]));
   const listingCount = await seedListings(userMap, categoryMap, tagMap);
 
   console.log("\n─────────────────────────────────────────");
-  console.log(`Wiped   ${wiped} demo account(s)`);
-  console.log(`Created 5 users`);
+  console.log(`Accounts 5 (reused or created)`);
+  console.log(`Wiped   ${wiped} old listing(s)`);
   console.log(`Created ${listingCount} listings`);
   console.log("\nDone. Run 'npm run dev' to browse the seeded marketplace.");
 }

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## feat: CM-US-050 — staging seed data script                                                                                                           
  
  Adds a seed script for populating the staging environment with demo accounts and listings before demos or rehearsals.                                                                                                                                                                                             
  ## New files                                                                                                                                            
  
  **`scripts/seed-staging.ts`** — The main seed script. Run with `npm run seed`. On each run it:
  - Creates the 5 demo accounts the first time, then reuses them on subsequent runs (avoids Supabase auth rate limits from repeated create/delete)        
  - Wipes all listings owned by those accounts
  - Uploads one real photo per category from Lorem Picsum to Supabase Storage
  - Creates 25 active listings across 5 sellers and 8 categories (textbooks, electronics, furniture, clothing, services, transport, sports, free stuff)   

  **`scripts/tsconfig.json`** — TypeScript config scoped to the `scripts/` directory so tsx resolves imports correctly when running the seed script       
  directly.

  ## Changed files

  **`package.json`** — Two new scripts:
  - `npm run seed` — full wipe + reseed
  - `npm run seed:wipe` — wipe listings only, keep accounts

  ## Demo accounts

  All accounts use password `demo1234` and are clearly labeled with `(Demo)` in their display names. Emails follow the pattern `demo.*@demo.edu` so       
  they're easy to identify.

  ## Notes

  - Safe to run multiple times — accounts persist, only listings are replaced
  - Never runs against production (exits if `NODE_ENV=production` or `SUPABASE_PROD_REF` matches the URL)
  - Requires `apps/backend/.env.local` with staging `SUPABASE_URL` and `SUPABASE_SERVICE_KEY`