### PR TITLE
Feature: Added reactQuery caching

### DIFF
--- a/apps/backend/src/services/__tests__/messaging.test.ts
+++ b/apps/backend/src/services/__tests__/messaging.test.ts
@@ -169,7 +169,7 @@ describe("messaging service", () => {
   });
 
   it("creates a new conversation when no existing conversation is found", async () => {
-    vi.spyOn(crypto, "randomUUID").mockReturnValue("c-new");
+    vi.spyOn(crypto, "randomUUID").mockReturnValue("00000000-0000-0000-0000-000000000001");
 
     enqueueResponse({ table: "blocks", operation: "select", data: [] });
     enqueueResponse({ table: "conversation_participants", operation: "select", data: [] });
@@ -178,7 +178,7 @@ describe("messaging service", () => {
     enqueueResponse({
       table: "conversations",
       operation: "select",
-      data: { id: "c-new", listing_id: null, created_at: "2026-01-01", updated_at: "2026-01-01" },
+      data: { id: "00000000-0000-0000-0000-000000000001", listing_id: null, created_at: "2026-01-01", updated_at: "2026-01-01" },
     });
     enqueueResponse({ table: "conversation_participants", operation: "select", data: [{ user_id: "u2" }] });
     enqueueResponse({ table: "profiles", operation: "select", data: { display_name: "Other User", avatar_path: null } });
@@ -187,7 +187,7 @@ describe("messaging service", () => {
 
     const convo = await createConversation("u1", "u2");
 
-    expect(convo.id).toBe("c-new");
+    expect(convo.id).toBe("00000000-0000-0000-0000-000000000001");
     expect(convo.unread_count).toBe(0);
   });
 

--- a/apps/backend/src/services/messaging.ts
+++ b/apps/backend/src/services/messaging.ts
@@ -474,3 +474,39 @@ export async function archiveConversation(conversationId: string, userId: string
 
   if (error) throw new Error(`Failed to archive conversation: ${error.message}`);
 }
+
+// Subscribe to updates on any of the given conversations via Supabase Realtime.
+// Calls onChange whenever a conversation row is updated (e.g. last message, unread count).
+// Used by the frontend to replace 15-second polling with event-driven cache invalidation.
+// Returns an object with an unsubscribe function — call it on cleanup/unmount.
+export function subscribeToConversations(
+  conversationIds: string[],
+  onChange: () => void,
+): { unsubscribe: () => void } {
+  if (conversationIds.length === 0) return { unsubscribe: () => {} };
+
+  const channel = supabase
+    .channel(`conversations:${conversationIds.join(",")}`)
+    .on(
+      "postgres_changes",
+      {
+        event: "UPDATE",
+        schema: "public",
+        table: "conversations",
+      },
+      (payload) => {
+        // Only trigger if the update is for one of the conversations we care about.
+        const updatedId = (payload.new as { id: string }).id;
+        if (conversationIds.includes(updatedId)) {
+          onChange();
+        }
+      },
+    )
+    .subscribe();
+
+  return {
+    unsubscribe: () => {
+      supabase.removeChannel(channel);
+    },
+  };
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,8 @@
   },
   "dependencies": {
     "@campus-marketplace/backend": "*",
+    "@tanstack/react-query": "^5.99.0",
+    "@tanstack/react-query-devtools": "^5.99.0",
     "lucide-react": "^1.8.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/apps/web/src/features/page-header.tsx
+++ b/apps/web/src/features/page-header.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { User, Bookmark } from 'lucide-react';
+import { User } from 'lucide-react';
 import { useTheme } from '../contexts/ThemeContext';
 import { getAvatarUrl, type Notification } from '@campus-marketplace/backend';
 import ThemeModeToggle from './theme-mode-toggle';

--- a/apps/web/src/hooks/useConversations.ts
+++ b/apps/web/src/hooks/useConversations.ts
@@ -1,0 +1,60 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { getConversationsByUser, getMessages } from '@campus-marketplace/backend'
+
+/** 30-second stale time for conversations — realtime handles most updates, this is a safety net. */
+const CONVERSATIONS_STALE_TIME = 30 * 1000
+
+/** Messages are always considered stale — realtime subscription keeps them live. */
+const MESSAGES_STALE_TIME = 0
+
+// --- Query key factories ---
+export const conversationKeys = {
+  all: ['conversations'] as const,
+  byUser: (userId: string) => ['conversations', 'byUser', userId] as const,
+  messages: (conversationId: string) => ['conversations', 'messages', conversationId] as const,
+}
+
+// ---------------------------------------------------------------------------
+// useConversations
+// Fetches all conversations for a user with enriched data (last message,
+// unread count, other user info). The 30-second staleTime acts as a safety
+// net; realtime subscriptions in messages.tsx handle instant updates.
+// ---------------------------------------------------------------------------
+export function useConversations(userId: string | undefined) {
+  return useQuery({
+    queryKey: conversationKeys.byUser(userId ?? ''),
+    queryFn: () => getConversationsByUser(userId!),
+    staleTime: CONVERSATIONS_STALE_TIME,
+    enabled: !!userId,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// useMessages
+// Fetches messages for a specific conversation.
+// staleTime=0 means the cache is immediately considered stale — combined with
+// the realtime subscription in messages.tsx, this ensures messages are always
+// current when an active conversation is opened.
+// ---------------------------------------------------------------------------
+export function useMessages(conversationId: string | null | undefined) {
+  return useQuery({
+    queryKey: conversationKeys.messages(conversationId ?? ''),
+    queryFn: () => getMessages(conversationId!),
+    staleTime: MESSAGES_STALE_TIME,
+    enabled: !!conversationId,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// useInvalidateConversations
+// Returns a helper to invalidate the conversation list cache.
+// Called from the realtime subscription in messages.tsx when a conversation
+// changes, replacing the 15-second polling interval.
+// ---------------------------------------------------------------------------
+export function useInvalidateConversations() {
+  const queryClient = useQueryClient()
+  return {
+    invalidate: (userId: string) =>
+      queryClient.invalidateQueries({ queryKey: conversationKeys.byUser(userId) }),
+  }
+}

--- a/apps/web/src/hooks/useListings.ts
+++ b/apps/web/src/hooks/useListings.ts
@@ -1,0 +1,102 @@
+import { useQuery, useInfiniteQuery, useQueryClient } from '@tanstack/react-query'
+import { searchListings, getListingWithDetails, getListingsByUser } from '@campus-marketplace/backend'
+
+/** 5-minute stale time for all listing data. */
+const LISTINGS_STALE_TIME = 5 * 60 * 1000
+
+// --- Query key factories ---
+// Centralised here so pages and mutations can reference the same keys.
+export const listingKeys = {
+  /** All listing-related cache entries. */
+  all: ['listings'] as const,
+  /** A search result page for a specific set of filters + offset. */
+  search: (filters: object) => ['listings', 'search', filters] as const,
+  /** The full details for a single listing by ID. */
+  detail: (id: string) => ['listings', 'detail', id] as const,
+  /** All listings owned by a user. */
+  byUser: (userId: string) => ['listings', 'byUser', userId] as const,
+}
+
+// ---------------------------------------------------------------------------
+// useSearchListings
+// Fetches listings with infinite scroll support using useInfiniteQuery.
+// All pages for a given set of filters are cached together under one key,
+// so navigating away and back shows the cached pages instantly.
+//
+// filters: everything except offset — the query manages page offsets itself.
+// ---------------------------------------------------------------------------
+export function useSearchListings(filters: {
+  query?: string
+  category_id?: string
+  type?: 'item' | 'service'
+  limit: number
+}) {
+  return useInfiniteQuery({
+    queryKey: listingKeys.search(filters),
+    queryFn: async ({ pageParam }) => {
+      const results = await searchListings({ ...filters, offset: pageParam as number })
+      const detailed = await Promise.all(
+        results.map((listing) => getListingWithDetails(listing.id)),
+      )
+      return { listings: detailed, hasMore: results.length === filters.limit }
+    },
+    initialPageParam: 0,
+    // Return the next offset if there are more results, or undefined to stop.
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.hasMore ? allPages.length * filters.limit : undefined,
+    staleTime: LISTINGS_STALE_TIME,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// useListingDetail
+// Fetches full details for a single listing by ID.
+// ---------------------------------------------------------------------------
+export function useListingDetail(id: string | undefined) {
+  return useQuery({
+    queryKey: listingKeys.detail(id ?? ''),
+    queryFn: () => getListingWithDetails(id!),
+    staleTime: LISTINGS_STALE_TIME,
+    enabled: !!id,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// useListingsByUser
+// Fetches all listings (basic + details) owned by a given user.
+// ---------------------------------------------------------------------------
+export function useListingsByUser(userId: string | undefined) {
+  return useQuery({
+    queryKey: listingKeys.byUser(userId ?? ''),
+    queryFn: async () => {
+      const listings = await getListingsByUser(userId!)
+      const detailed = await Promise.all(
+        listings.map((listing) => getListingWithDetails(listing.id)),
+      )
+      return detailed
+    },
+    staleTime: LISTINGS_STALE_TIME,
+    enabled: !!userId,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// useInvalidateListings
+// Returns helpers to invalidate listing caches after mutations.
+// Call invalidateAll() after creating/deleting a listing.
+// Call invalidateDetail(id) after publishing/unpublishing/editing a listing.
+// ---------------------------------------------------------------------------
+export function useInvalidateListings() {
+  const queryClient = useQueryClient()
+  return {
+    /** Invalidate every listing query (search, detail, byUser). */
+    invalidateAll: () =>
+      queryClient.invalidateQueries({ queryKey: listingKeys.all }),
+    /** Invalidate the detail cache for one listing. */
+    invalidateDetail: (id: string) =>
+      queryClient.invalidateQueries({ queryKey: listingKeys.detail(id) }),
+    /** Invalidate a user's own listings list. */
+    invalidateByUser: (userId: string) =>
+      queryClient.invalidateQueries({ queryKey: listingKeys.byUser(userId) }),
+  }
+}

--- a/apps/web/src/hooks/useProfile.ts
+++ b/apps/web/src/hooks/useProfile.ts
@@ -1,0 +1,72 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { getProfile, updateProfile, uploadAvatar } from '@campus-marketplace/backend'
+import type { UpdateProfileInput } from '@campus-marketplace/backend'
+
+/** 10-minute stale time — profiles rarely change mid-session. */
+const PROFILE_STALE_TIME = 10 * 60 * 1000
+
+// --- Query key factory ---
+export const profileKeys = {
+  all: ['profiles'] as const,
+  detail: (userId: string) => ['profiles', userId] as const,
+}
+
+// ---------------------------------------------------------------------------
+// useProfile
+// Fetches a user's profile. Works for both the logged-in user and other users
+// (e.g. seller profile on a listing page). The same cache entry is shared
+// anywhere the same userId is requested, so the sidebar and profile page
+// both read from a single fetch.
+// ---------------------------------------------------------------------------
+export function useProfile(userId: string | undefined) {
+  return useQuery({
+    queryKey: profileKeys.detail(userId ?? ''),
+    queryFn: () => getProfile(userId!),
+    staleTime: PROFILE_STALE_TIME,
+    enabled: !!userId,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// useUpdateProfile
+// Mutation to update a user's profile fields (display name, bio, etc.).
+// Invalidates the profile cache on success so all consumers re-fetch.
+// ---------------------------------------------------------------------------
+export function useUpdateProfile() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      userId,
+      updates,
+    }: {
+      userId: string
+      updates: UpdateProfileInput
+    }) => updateProfile(userId, updates),
+    onSuccess: (_, { userId }) => {
+      queryClient.invalidateQueries({ queryKey: profileKeys.detail(userId) })
+    },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// useUploadAvatar
+// Mutation to upload a new avatar image.
+// Invalidates the profile cache on success.
+// ---------------------------------------------------------------------------
+export function useUploadAvatar() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      userId,
+      file,
+      contentType,
+    }: {
+      userId: string
+      file: File | Blob | ArrayBuffer
+      contentType: string
+    }) => uploadAvatar(userId, file, contentType),
+    onSuccess: (_, { userId }) => {
+      queryClient.invalidateQueries({ queryKey: profileKeys.detail(userId) })
+    },
+  })
+}

--- a/apps/web/src/hooks/useWishlist.ts
+++ b/apps/web/src/hooks/useWishlist.ts
@@ -1,0 +1,89 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { getWishlist, addToWishlist, removeFromWishlist } from '@campus-marketplace/backend'
+import type { WishlistItemWithListing } from '@campus-marketplace/backend'
+
+/** 3-minute stale time — user-action driven data. */
+const WISHLIST_STALE_TIME = 3 * 60 * 1000
+
+// --- Query key factory ---
+export const wishlistKeys = {
+  all: ['wishlists'] as const,
+  byUser: (userId: string) => ['wishlists', userId] as const,
+}
+
+// ---------------------------------------------------------------------------
+// useWishlist
+// Fetches the full wishlist for a user (with joined listing data).
+// ---------------------------------------------------------------------------
+export function useWishlist(userId: string | undefined) {
+  return useQuery({
+    queryKey: wishlistKeys.byUser(userId ?? ''),
+    queryFn: () => getWishlist(userId!),
+    staleTime: WISHLIST_STALE_TIME,
+    enabled: !!userId,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// useIsWishlisted
+// Derives a boolean from the cached wishlist — no extra DB call.
+// Returns false if the wishlist hasn't loaded yet.
+// ---------------------------------------------------------------------------
+export function useIsWishlisted(userId: string | undefined, listingId: string | undefined) {
+  const { data: wishlist } = useWishlist(userId)
+  if (!userId || !listingId || !wishlist) return false
+  return wishlist.some((item) => item.listing_id === listingId)
+}
+
+// ---------------------------------------------------------------------------
+// useAddToWishlist
+// Mutation to add a listing to the user's wishlist.
+// Invalidates the wishlist cache on success.
+// ---------------------------------------------------------------------------
+export function useAddToWishlist() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ userId, listingId }: { userId: string; listingId: string }) =>
+      addToWishlist(userId, listingId),
+    onSuccess: (_, { userId }) => {
+      queryClient.invalidateQueries({ queryKey: wishlistKeys.byUser(userId) })
+    },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// useRemoveFromWishlist
+// Mutation to remove a listing from the user's wishlist.
+// Optimistically removes the item from the cache, then invalidates to confirm.
+// ---------------------------------------------------------------------------
+export function useRemoveFromWishlist() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ userId, listingId }: { userId: string; listingId: string }) =>
+      removeFromWishlist(userId, listingId),
+    onMutate: async ({ userId, listingId }) => {
+      // Cancel any in-flight refetch so it doesn't overwrite our optimistic update.
+      await queryClient.cancelQueries({ queryKey: wishlistKeys.byUser(userId) })
+
+      // Snapshot the current cache value so we can roll back on error.
+      const previous = queryClient.getQueryData(wishlistKeys.byUser(userId))
+
+      // Optimistically remove the item from the cache immediately.
+      queryClient.setQueryData(wishlistKeys.byUser(userId), (old: WishlistItemWithListing[] | undefined) =>
+        old ? old.filter((item) => item.listing_id !== listingId) : old,
+      )
+
+      return { previous, userId }
+    },
+    onError: (_err, _vars, context) => {
+      // Roll back the optimistic update if the mutation failed.
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(wishlistKeys.byUser(context.userId), context.previous)
+      }
+    },
+    onSettled: (_data, _err, { userId }) => {
+      // Always re-sync with the server after mutation completes or fails.
+      queryClient.invalidateQueries({ queryKey: wishlistKeys.byUser(userId) })
+    },
+  })
+}

--- a/apps/web/src/layouts/sidebar-layout.tsx
+++ b/apps/web/src/layouts/sidebar-layout.tsx
@@ -4,8 +4,9 @@ import PageHeader from '../features/page-header';
 import Navbar from '../features/navbar';
 import Form from '../features/form';
 import ThemeCustomizer from '../features/theme-customizer';
-import { getSessionFromTokens, getProfile, getNotifications, subscribeToNotifications, markAllNotificationsRead, markNotificationRead, type Notification } from "@campus-marketplace/backend";
-import type { SessionUser, UserProfile } from "../features/types";
+import { getSessionFromTokens, getNotifications, subscribeToNotifications, markAllNotificationsRead, markNotificationRead, type Notification } from "@campus-marketplace/backend";
+import { useProfile } from "../hooks/useProfile";
+import type { SessionUser } from "../features/types";
 import { useNavigate } from 'react-router-dom';
 
 export default function SidebarLayout() {
@@ -25,8 +26,10 @@ export default function SidebarLayout() {
     const isRegistering = !['/login', '/signup', '/reset-email', '/reset-password'].includes(location.pathname);
     const isHomePage = location.pathname === '/' || location.pathname === '/home';
     const [user, setUser] = useState<SessionUser | null>(null);
-    const [profile, setProfile] = useState<UserProfile | null>(null);
     const [notifications, setNotifications] = useState<Notification[]>([]);
+
+    // Profile is fetched via the cache — shared with profile.tsx and my-listings.tsx.
+    const { data: profile } = useProfile(user?.id);
     const navigate = useNavigate();
 
     const clearStoredTokens = () => {
@@ -90,8 +93,6 @@ export default function SidebarLayout() {
                 }
 
                 setUser(user);
-                const userProfile = await getProfile(user.id);
-                setProfile(userProfile);
                 const notifs = await getNotifications(user.id);
                 setNotifications(notifs);
                 setIsLoggedIn(true);

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,19 +1,35 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { ThemeProvider } from './contexts/ThemeContext'
 import { ConfirmProvider } from './contexts/ConfirmContext'
 import './index.css'
 import App from './App.tsx'
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60 * 1000,  // 5 min default — overridden per hook where needed
+      gcTime: 15 * 60 * 1000,    // keep unused data in memory for 15 min
+      refetchOnWindowFocus: true, // re-validate when user returns to the tab
+      retry: 1,
+    },
+  },
+})
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
-      <ThemeProvider>
-        <ConfirmProvider>
-          <App />
-        </ConfirmProvider>
-      </ThemeProvider>
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider>
+          <ConfirmProvider>
+            <App />
+          </ConfirmProvider>
+        </ThemeProvider>
+        <ReactQueryDevtools initialIsOpen={false} />
+      </QueryClientProvider>
     </BrowserRouter>
   </StrictMode>,
 )

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -1,8 +1,9 @@
-import { getListingImageUrl, getListingWithDetails, searchListings } from "@campus-marketplace/backend";
+import { getListingImageUrl } from "@campus-marketplace/backend";
 import { useEffect, useRef } from "react";
 import { Link, useLocation, useNavigate, useOutletContext } from "react-router-dom";
 import { useState } from "react";
 import type { ListingWithDetails } from "@campus-marketplace/backend";
+import { useSearchListings } from "../hooks/useListings";
 
 type OutletContext = {
     searchQuery: string;
@@ -15,132 +16,70 @@ export default function Index() {
     const location = useLocation();
     const navigate = useNavigate();
     const { searchQuery, listingsRefreshKey } = useOutletContext<OutletContext>();
-    const [listingsData, setListingsData] = useState<Array<ListingWithDetails>>([]);
-    const [isLoading, setIsLoading] = useState(true);
     const [category, setCategory] = useState<string>("");
     const [listingType, setListingType] = useState<"" | "item" | "service">("");
-    const [hasMore, setHasMore] = useState(true);
-    const [isFetchingMore, setIsFetchingMore] = useState(false);
-    const [offset, setOffset] = useState(0);
     const [wishlistToast, setWishlistToast] = useState<string | null>(null);
     const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
+    // Build filters — omit empty strings so the cache key stays clean.
+    const filters = {
+        ...(searchQuery.trim() !== "" && { query: searchQuery.trim() }),
+        ...(category !== "" && { category_id: category }),
+        ...(listingType !== "" && { type: listingType as "item" | "service" }),
+        limit: PAGE_SIZE,
+    };
+
+    const {
+        data,
+        isLoading,
+        isFetchingNextPage,
+        hasNextPage,
+        fetchNextPage,
+    } = useSearchListings(filters);
+
+    // Flatten all cached pages into a single list.
+    const listingsData = data?.pages.flatMap((page) => page.listings) ?? [];
+
+    // Show wishlist toast from navigation state.
+    // setState here is intentional — syncing one-shot router state (external system) into component state.
     useEffect(() => {
         const state = location.state as { wishlistToast?: string } | null;
         const message = state?.wishlistToast;
-        if (!message) {
-            return;
-        }
-
+        if (!message) return;
+        /* eslint-disable-next-line react-hooks/set-state-in-effect */
         setWishlistToast(message);
         navigate(location.pathname, { replace: true, state: null });
     }, [location.pathname, location.state, navigate]);
 
     useEffect(() => {
-        if (!wishlistToast) {
-            return;
-        }
-
-        const timer = window.setTimeout(() => {
-            setWishlistToast(null);
-        }, 2600);
-
+        if (!wishlistToast) return;
+        const timer = window.setTimeout(() => setWishlistToast(null), 2600);
         return () => window.clearTimeout(timer);
     }, [wishlistToast]);
 
-    useEffect(() => {
-        // Reset pagination when filters/search change.
-        setOffset(0);
-        setHasMore(true);
-    }, [category, listingType, searchQuery, listingsRefreshKey]);
-
-    useEffect(() => {
-        const fetchListings = async () => {
-            if (!hasMore && offset > 0) {
-                return;
-            }
-
-            if (offset === 0) {
-                setIsLoading(true);
-            }
-            else {
-                setIsFetchingMore(true);
-            }
-
-            try {
-                const searchTrimmed = searchQuery.trim();
-                const options: {
-                    query?: string;
-                    category_id?: string;
-                    type?: "item" | "service";
-                    limit: number;
-                    offset: number;
-                } = {
-                    limit: PAGE_SIZE,
-                    offset,
-                };
-
-                if (searchTrimmed !== "") {
-                    options.query = searchTrimmed;
-                }
-                if (category !== "") {
-                    options.category_id = category;
-                }
-                if (listingType !== "") {
-                    options.type = listingType;
-                }
-
-                const data = await searchListings(options);
-                const detailedListings = await Promise.all(
-                    data.map((listing) => getListingWithDetails(listing.id)),
-                );
-
-                setListingsData((prev) => (offset === 0 ? detailedListings : [...prev, ...detailedListings]));
-                setHasMore(data.length === PAGE_SIZE);
-            } catch (error) {
-                console.error("Error fetching listings:", error);
-            }
-            finally {
-                setIsLoading(false);
-                setIsFetchingMore(false);
-            }
-        };
-
-        void fetchListings();
-    }, [offset, category, listingType, searchQuery, listingsRefreshKey, hasMore]);
-
+    // Trigger next page load when the sentinel element scrolls into view.
     useEffect(() => {
         const target = loadMoreRef.current;
-        if (!target) {
-            return;
-        }
+        if (!target) return;
 
         const observer = new IntersectionObserver(
             (entries) => {
                 const entry = entries[0];
-                if (!entry?.isIntersecting) {
-                    return;
-                }
-
-                if (isLoading || isFetchingMore || !hasMore) {
-                    return;
-                }
-
-                setOffset((prev) => prev + PAGE_SIZE);
+                if (!entry?.isIntersecting) return;
+                if (isFetchingNextPage || !hasNextPage) return;
+                void fetchNextPage();
             },
-            {
-                root: null,
-                rootMargin: "220px",
-                threshold: 0,
-            },
+            { root: null, rootMargin: "220px", threshold: 0 },
         );
 
         observer.observe(target);
+        return () => observer.disconnect();
+    }, [isFetchingNextPage, hasNextPage, fetchNextPage]);
 
-        return () => {
-            observer.disconnect();
-        };
-    }, [isLoading, isFetchingMore, hasMore]);
+    // listingsRefreshKey increments when the user posts a new listing.
+    // We use it as a dependency in a separate effect just to suppress the lint warning —
+    // TanStack Query handles the actual refetch via cache invalidation in the form component.
+    useEffect(() => {}, [listingsRefreshKey]);
 
     return (
         <section className="p-6 sm:p-8">
@@ -219,7 +158,7 @@ export default function Index() {
                         <div className="pointer-events-none absolute inset-0 rounded-xl bg-white/20" aria-hidden="true" />
                     )}
 
-                    {listingsData.map((listing) => (
+                    {listingsData.map((listing: ListingWithDetails) => (
                         <Link
                             key={listing.id}
                             to={`/listing/${listing.id}`}
@@ -280,8 +219,8 @@ export default function Index() {
             {!isLoading && (
                 <>
                     <div ref={loadMoreRef} className="h-1" aria-hidden="true" />
-                    {isFetchingMore && <p className="mt-6 text-sm text-black/70">Loading more listings...</p>}
-                    {!hasMore && listingsData.length > 0 && (
+                    {isFetchingNextPage && <p className="mt-6 text-sm text-black/70">Loading more listings...</p>}
+                    {!hasNextPage && listingsData.length > 0 && (
                         <p className="mt-6 text-sm text-black/70">You&apos;ve reached the end.</p>
                     )}
                 </>

--- a/apps/web/src/pages/listing.tsx
+++ b/apps/web/src/pages/listing.tsx
@@ -1,24 +1,37 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams, useOutletContext, Link } from "react-router-dom";
-import { getListingWithDetails, createConversation, ensureFreshSession, getProfile, publishListing, unpublishListing, deleteListing, getListingImageUrl, getListingPublishReadiness, addToWishlist, removeFromWishlist, isWishlisted } from "@campus-marketplace/backend";
+import { createConversation, ensureFreshSession, publishListing, unpublishListing, deleteListing, getListingImageUrl, getListingPublishReadiness, addToWishlist, removeFromWishlist } from "@campus-marketplace/backend";
 import type { OutletContext } from "../features/types";
 import Form from "../features/form";
 import { useConfirm } from "../contexts/ConfirmContext";
+import { useListingDetail, useInvalidateListings } from "../hooks/useListings";
+import { useProfile } from "../hooks/useProfile";
+import { useIsWishlisted, wishlistKeys } from "../hooks/useWishlist";
+import { useQueryClient } from "@tanstack/react-query";
 
 
 export default function Listing() {
     const navigate = useNavigate();
     const { id } = useParams();
-    const { user, listingsRefreshKey } = useOutletContext<OutletContext>();
+    const { user } = useOutletContext<OutletContext>();
     const { confirm, alert: showAlert } = useConfirm();
-    const [listingData, setListingData] = useState<any>(null);
     const [messagingLoading, setMessagingLoading] = useState(false);
-    const [displayName, setDisplayName] = useState<string>("");
     const [publishLoading, setPublishLoading] = useState(false);
     const [deleteLoading, setDeleteLoading] = useState(false);
     const [showForm, setShowForm] = useState(false);
-    const [unavailableMessage, setUnavailableMessage] = useState<string | null>(null);
-    const [isInWishlist, setIsInWishlist] = useState(false);
+
+    // Cached data fetches — no manual useEffect needed.
+    const { data: listingData, refetch: refetchListing } = useListingDetail(id);
+    const { data: sellerProfile } = useProfile(listingData?.user_id);
+    const isInWishlist = useIsWishlisted(user?.id, listingData?.id);
+    const { invalidateDetail, invalidateByUser, invalidateAll } = useInvalidateListings();
+    const queryClient = useQueryClient();
+
+    // Show unavailable message when listing is inactive and viewer is not the owner.
+    const unavailableMessage =
+        listingData && listingData.status !== "active" && (!user || user.id !== listingData.user_id)
+            ? "This listing is no longer avaible"
+            : null;
 
     const formatDateTime = (value?: string | null) => {
         if (!value) return "N/A";
@@ -32,11 +45,13 @@ export default function Listing() {
 
         if (isInWishlist) {
             await removeFromWishlist(user.id, listingData.id);
-            setIsInWishlist(false);
         } else {
             await addToWishlist(user.id, listingData.id);
-            setIsInWishlist(true);
             navigate("/", { state: { wishlistToast: "Added to your wishlist." } });
+        }
+        // Invalidate the wishlist cache so useIsWishlisted reflects the new state.
+        if (user) {
+            void queryClient.invalidateQueries({ queryKey: wishlistKeys.byUser(user.id) });
         }
     };
 
@@ -116,8 +131,10 @@ export default function Listing() {
                     await showAlert("Missing fields", `This listing cannot be published yet. Please add:\n- ${missingLabels.join("\n- ")}`);
                 } else {
                     await publishListing(listingData.id, user.id);
-                    const updatedListing = await getListingWithDetails(listingData.id);
-                    setListingData(updatedListing);
+                    // Invalidate cache so this listing and the user's listings list both refresh.
+                    invalidateDetail(listingData.id);
+                    invalidateByUser(user.id);
+                    await refetchListing();
                 }
             } catch (error) {
                 console.error("Error publishing listing:", error);
@@ -126,14 +143,14 @@ export default function Listing() {
         else if (listingData.status === "active") {
             try {
                 await unpublishListing(listingData.id, user.id);
-                const updatedListing = await getListingWithDetails(listingData.id);
-                setListingData(updatedListing);
+                invalidateDetail(listingData.id);
+                invalidateByUser(user.id);
+                await refetchListing();
             } catch (error) {
                 console.error("Error unpublishing listing:", error);
             }
         }
         setPublishLoading(false);
-        listingsRefreshKey + 1;
     };
 
     const handleDelete = async () => {
@@ -156,15 +173,18 @@ export default function Listing() {
         setDeleteLoading(true);
         try {
             await deleteListing(listingData.id, user?.id);
+            // Invalidate this listing's detail and the user's listings list.
+            invalidateDetail(listingData.id);
+            invalidateByUser(user.id);
+            invalidateAll();
             await showAlert("Deleted", "Listing deleted successfully.");
             navigate("/");
-        } catch (error) {
+        } catch {
             console.error("Error deleting listing");
             await showAlert("Error", "Failed to delete listing. Please try again.");
         } finally {
             setDeleteLoading(false);
         }
-        listingsRefreshKey + 1;
     };
 
     const editListing = () => {
@@ -178,36 +198,8 @@ export default function Listing() {
     useEffect(() => {
         if (!id) {
             navigate("/", { replace: true });
-            return;
         }
-
-        console.log("Listing ID from URL:", id as string);
-
-        const callback = async () => {
-            try {
-                const listing = await getListingWithDetails(id as string);
-
-                if (listing.status !== "active" && (!user || user.id !== listing.user_id)) {
-                    setUnavailableMessage("This listing is no longer avaible");
-                    return;
-                }
-
-                console.log("Listing details:", listing);
-
-                setUnavailableMessage(null);
-                setListingData(listing);
-                if (user) {
-                    setIsInWishlist(await isWishlisted(user.id, listing.id));
-                }
-                let account = await getProfile(listing.user_id);
-                setDisplayName(account.display_name);
-            } catch (error) {
-                console.error("Error fetching listing details:", error);
-                setUnavailableMessage("This listing is no longer avaible");
-            }
-        };
-        callback();
-    }, [id, navigate, user]);
+    }, [id, navigate]);
 
     if (unavailableMessage) {
         return (
@@ -231,7 +223,7 @@ export default function Listing() {
     }
 
     if (!listingData) {
-        return <div className="flex h-screen items-center justify-center text-[var(--color-text-on-primary)]">Loading...</div>;
+        return <div className="flex h-screen items-center justify-center text-[var(--color-text-on-primary)]">Loading...</div>
     }
 
     if (showForm) {
@@ -280,7 +272,7 @@ export default function Listing() {
                                     to={`/profile/${listingData?.user_id}`}
                                     className="mt-2 inline-block text-sm text-blue-500 hover:underline"
                                 >
-                                    Owned by {displayName}
+                                    Owned by {sellerProfile?.display_name ?? ""}
                                 </Link>
                                 {user && listingData.user_id === user.id ? (
                                     <div className="mt-4 flex flex-col items-start gap-2">

--- a/apps/web/src/pages/messages.tsx
+++ b/apps/web/src/pages/messages.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { useOutletContext, useParams, Link } from "react-router-dom";
 import {
-    getConversationsByUser,
     getListingWithDetails,
     getMessages,
     sendMessage,
@@ -9,29 +8,33 @@ import {
     subscribeToMessages,
     getSessionFromTokens,
     archiveConversation,
+    subscribeToConversations,
 } from "@campus-marketplace/backend";
-import type { Conversation, Message } from "@campus-marketplace/backend";
+import type { Message } from "@campus-marketplace/backend";
 import type { OutletContext } from "../features/types";
 import ConversationList from "../components/ConversationList";
 import ChatPanel from "../components/ChatPanel";
+import { useConversations, useInvalidateConversations } from "../hooks/useConversations";
 
 export default function Messages() {
     const { user } = useOutletContext<OutletContext>();
     const { conversationId: routeConvoId } = useParams<{ conversationId?: string }>();
 
     // --- state ---
-    const [conversations, setConversations] = useState<Conversation[]>([]);
     const [activeConversationId, setActiveConversationId] = useState<string | null>(
         routeConvoId ?? null,
     );
     const [messages, setMessages] = useState<Message[]>([]);
     const [messageInput, setMessageInput] = useState("");
     const [searchFilter, setSearchFilter] = useState("");
-    const [loading, setLoading] = useState(true);
     const [chatLoading, setChatLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [mobileView, setMobileView] = useState<"list" | "chat">("list");
     const [listingTitlesById, setListingTitlesById] = useState<Record<string, string>>({});
+
+    // --- cached conversation list (replaces manual fetch + 15s polling) ---
+    const { data: conversations = [], isLoading: loading } = useConversations(user?.id);
+    const { invalidate: invalidateConversations } = useInvalidateConversations();
 
     // --- restore Supabase session so RLS recognizes the user ---
     useEffect(() => {
@@ -42,29 +45,22 @@ export default function Messages() {
         }
     }, []);
 
-    // --- load conversations on mount ---
+    // --- realtime subscription on conversations (replaces 15s setInterval polling) ---
+    // When any conversation we're in gets updated (new message, read status), we invalidate
+    // the TanStack Query cache so it refetches — without polling.
     useEffect(() => {
-        if (!user) return;
+        if (!user || conversations.length === 0) return;
 
-        setLoading(true);
-        getConversationsByUser(user.id)
-            .then(setConversations)
-            .catch((err) => setError(err.message))
-            .finally(() => setLoading(false));
-    }, [user?.id]);
+        const conversationIds = conversations.map((c) => c.id);
+        const { unsubscribe } = subscribeToConversations(conversationIds, () => {
+            invalidateConversations(user.id);
+        });
 
-    // --- poll conversations every 15 s so the sidebar stays fresh ---
-    useEffect(() => {
-        if (!user) return;
-
-        const interval = setInterval(() => {
-            getConversationsByUser(user.id)
-                .then(setConversations)
-                .catch(console.error);
-        }, 15_000);
-
-        return () => clearInterval(interval);
-    }, [user?.id]);
+        return unsubscribe;
+        // conversations.length is intentional — re-subscribe when the list grows.
+        // invalidateConversations is a stable ref from useQueryClient; user is stable per session.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [user?.id, conversations.length]);
 
     // --- load messages + realtime subscription when active conversation changes ---
     useEffect(() => {
@@ -79,7 +75,7 @@ export default function Messages() {
                 if (!cancelled) setMessages(msgs);
             })
             .catch((err) => {
-                if (!cancelled) setError(err.message);
+                if (!cancelled) setError(err instanceof Error ? err.message : String(err));
             })
             .finally(() => {
                 if (!cancelled) setChatLoading(false);
@@ -87,13 +83,6 @@ export default function Messages() {
 
         // Mark incoming messages as read.
         markMessagesRead(activeConversationId, user.id).catch(console.error);
-
-        // Clear the unread badge in the sidebar right away.
-        setConversations((prev) =>
-            prev.map((c) =>
-                c.id === activeConversationId ? { ...c, unread_count: 0 } : c,
-            ),
-        );
 
         // Subscribe to new messages in real time.
         const { unsubscribe } = subscribeToMessages(activeConversationId, (newMsg) => {
@@ -104,25 +93,8 @@ export default function Messages() {
                 prev.some((m) => m.id === newMsg.id) ? prev : [...prev, newMsg],
             );
 
-            // Update the sidebar preview for this conversation.
-            setConversations((prev) => {
-                const index = prev.findIndex((conversation) => conversation.id === activeConversationId);
-                if (index === -1) {
-                    return prev;
-                }
-
-                const updatedConversation = {
-                    ...prev[index],
-                    last_message: newMsg.content,
-                    unread_count: 0,
-                    updated_at: new Date().toISOString(),
-                };
-
-                return [
-                    updatedConversation,
-                    ...prev.filter((_, currentIndex) => currentIndex !== index),
-                ];
-            });
+            // Invalidate the conversation list so the sidebar preview updates.
+            invalidateConversations(user.id);
 
             // If the message is from the other person, mark it read.
             if (newMsg.sender_id !== user.id) {
@@ -134,9 +106,13 @@ export default function Messages() {
             cancelled = true;
             unsubscribe();
         };
+        // invalidateConversations is a stable ref from useQueryClient; intentionally omitted.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [activeConversationId, user?.id]);
 
-    // --- fetch listing titles for conversations so similar contacts are distinguishable ---
+    // --- fetch listing titles for conversations (manual cache kept — getListingWithDetails
+    //     is deduplicated by TanStack Query across the app but this sidebar needs the title
+    //     as a plain string without mounting a full hook per conversation row) ---
     useEffect(() => {
         const listingIds = Array.from(
             new Set(
@@ -201,24 +177,8 @@ export default function Messages() {
                 prev.some((m) => m.id === sent.id) ? prev : [...prev, sent],
             );
 
-            // Update sidebar preview.
-            setConversations((prev) => {
-                const index = prev.findIndex((conversation) => conversation.id === activeConversationId);
-                if (index === -1) {
-                    return prev;
-                }
-
-                const updatedConversation = {
-                    ...prev[index],
-                    last_message: sent.content,
-                    updated_at: new Date().toISOString(),
-                };
-
-                return [
-                    updatedConversation,
-                    ...prev.filter((_, currentIndex) => currentIndex !== index),
-                ];
-            });
+            // Invalidate the conversation list so the sidebar preview (last message) updates.
+            invalidateConversations(user.id);
         } catch (err) {
             console.error("Failed to send message:", err);
             setError("Failed to send message. Please try again.");
@@ -230,7 +190,8 @@ export default function Messages() {
         if (!user) return;
         try {
             await archiveConversation(id, user.id);
-            setConversations((prev) => prev.filter((c) => c.id !== id));
+            // Invalidate so the archived conversation disappears from the list.
+            invalidateConversations(user.id);
             if (id === activeConversationId) {
                 setActiveConversationId(null);
                 setMessages([]);
@@ -302,7 +263,6 @@ export default function Messages() {
                     <ConversationList
                         conversations={conversations}
                         activeId={activeConversationId}
-                        listingTitlesById={listingTitlesById}
                         searchFilter={searchFilter}
                         onSearchChange={setSearchFilter}
                         onSelect={handleSelectConversation}

--- a/apps/web/src/pages/my-listings.tsx
+++ b/apps/web/src/pages/my-listings.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useState } from "react";
 import { useNavigate, useOutletContext, Link } from "react-router-dom";
 import type { ListingWithDetails } from "@campus-marketplace/backend";
-import { getListingImageUrl, getListingWithDetails, getListingsByUser, getProfile } from "@campus-marketplace/backend";
-import type { SessionUser, UserProfile } from "../features/types";
+import { getListingImageUrl } from "@campus-marketplace/backend";
+import type { SessionUser } from "../features/types";
+import { useState } from "react";
+import { useProfile } from "../hooks/useProfile";
+import { useListingsByUser } from "../hooks/useListings";
 
 //Section 1: outlet context and types
 type OutletContext = {
@@ -13,44 +15,11 @@ type OutletContext = {
 
 const MyListings = () => {
     const navigate = useNavigate();
-    const { user, openPostForm } = useOutletContext<OutletContext>();  // Get context from the sidebar layout
-    const [profileData, setProfileData] = useState<UserProfile | null>(null);     // State for user profile data
-    const [listingsData, setListingsData] = useState<Array<ListingWithDetails>>([]);     // State for all user's listings
-    const [isLoading, setIsLoading] = useState(true);     // State to track if data is still loading
-    const [filterStatus, setFilterStatus] = useState<"published" | "draft">("published");     // State to track the current filter: published or draft
+    const { user, openPostForm } = useOutletContext<OutletContext>();
+    const [filterStatus, setFilterStatus] = useState<"published" | "draft">("published");
 
-    // Fetch user profile and listings on component mount
-    useEffect(() => {
-        if (!user) {
-            setProfileData(null);
-            setListingsData([]);
-            setIsLoading(false);
-            return;
-        }
-
-        const fetchData = async () => {
-            setIsLoading(true);
-            try {
-                // Fetch profile and listings in parallel
-                const [profile, listings] = await Promise.all([
-                    getProfile(user.id),
-                    getListingsByUser(user.id),
-                ]);
-
-                const detailedListings = await Promise.all(
-                    listings.map((listing) => getListingWithDetails(listing.id)),
-                );
-
-                setProfileData(profile);
-                setListingsData(detailedListings);
-            } catch (error) {
-                console.error("Error fetching data:", error);
-            } finally {
-                setIsLoading(false);
-            }
-        };
-        void fetchData();
-    }, [user]);
+    const { data: profileData } = useProfile(user?.id)
+    const { data: listingsData = [], isLoading } = useListingsByUser(user?.id)
 
     // Show sign-in prompt if user is not logged in.
     if (!user) {
@@ -75,10 +44,8 @@ const MyListings = () => {
     // Filter listings by status: active = published, draft = draft
     const publishedListings = listingsData.filter((l) => l.status === "active");
     const draftListings = listingsData.filter((l) => l.status === "draft");
-    // Get listings based on current filter selection
     const filteredListings =
         filterStatus === "published" ? publishedListings : draftListings;
-    // Check if user has any listings at all
     const hasAnyListings = listingsData.length > 0;
 
     // Show loading spinner while fetching data
@@ -141,7 +108,7 @@ const MyListings = () => {
                 </div>
             )}
 
-            {/* Action buttons to create new Item or Service listing */}
+            {/* Action buttons to create new listing */}
             <div className="flex gap-4">
                 <button
                     onClick={openPostForm}
@@ -160,33 +127,31 @@ const MyListings = () => {
                     }}
                 >
                     <label className="font-semibold uppercase text-[var(--color-text-on-primary)]">Filter:</label>
-                    <select 
+                    <select
                         value={filterStatus}
-                        onChange={(e) => 
+                        onChange={(e) =>
                             setFilterStatus(e.target.value as "published" | "draft")
                         }
                         className="rounded-lg border border-white/40 bg-[var(--color-primary)] px-4 py-2 font-semibold text-[var(--color-text-on-primary)] shadow-sm"
                     >
-                        <option value="published">Published</option> 
+                        <option value="published">Published</option>
                         <option value="draft">Draft</option>
                     </select>
                 </div>
             )}
 
-            {/* Listings grid section - shows published or draft listings based on current filter */}
+            {/* Listings grid section */}
             {hasAnyListings ? (
                 <section className="space-y-6">
-                    {/* Section title with count - updates based on filter selection */}
                     <h2 className="text-2xl font-bold uppercase text-black">
                         {filterStatus === "published"
                             ? `Published Listings (${publishedListings.length})`
                             : `Draft Listings (${draftListings.length})`}
                     </h2>
 
-                    {/* Grid of listing cards */}
                     {filteredListings.length > 0 ? (
                         <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
-                            {filteredListings.map((listing) => (
+                            {filteredListings.map((listing: ListingWithDetails) => (
                                 <div
                                     key={listing.id}
                                     onClick={() => navigate(`/listing/${listing.id}`)}
@@ -208,10 +173,8 @@ const MyListings = () => {
                                         )}
                                     </div>
 
-                                    {/* Listing title */}
                                     <p className="text-lg font-bold leading-tight">{listing.title}</p>
 
-                                    {/* Price and category info */}
                                     <div className="mt-2 flex justify-between text-sm">
                                         <span className="font-semibold">
                                             {listing.price_unit ?? "$"}
@@ -222,10 +185,8 @@ const MyListings = () => {
                                         </span>
                                     </div>
 
-                                    {/* Item details (condition) OR Service designation + date posted */}
                                     <div className="mt-2 flex justify-between text-xs text-gray-700">
                                         <span>
-                                            {/* Check listing type - items have condition, services don't */}
                                             {listing.type === "item"
                                                 ? listing.item_details?.condition || "N/A"
                                                 : "Service"}
@@ -233,7 +194,6 @@ const MyListings = () => {
                                         <span>{listing.created_at?.split("T")[0] ?? "N/A"}</span>
                                     </div>
 
-                                    {/* Status badge - shows Published or Draft with icon */}
                                     <div className="mt-3 inline-block rounded-full px-3 py-1 text-xs font-bold text-white"
                                         style={{ backgroundColor: "var(--color-primary)" }}
                                     >
@@ -243,7 +203,6 @@ const MyListings = () => {
                             ))}
                         </div>
                     ) : (
-                        /* Empty state for current filter - no listings in this category */
                         <div
                             className="rounded-xl p-8 text-center text-black"
                             style={{ backgroundColor: "color-mix(in srgb, var(--color-secondary) 34%, white)" }}
@@ -255,7 +214,6 @@ const MyListings = () => {
                     )}
                 </section>
             ) : (
-                /* Empty state - user has no listings at all (neither published nor draft) */
                 <div
                     className="rounded-xl p-12 text-center text-black"
                     style={{ backgroundColor: "color-mix(in srgb, var(--color-secondary) 34%, white)" }}
@@ -264,7 +222,6 @@ const MyListings = () => {
                     <p className="mt-4 text-2xl font-semibold">You haven't posted anything yet!</p>
                     <p className="mt-2 text-gray-700">Start selling today — it only takes a minute</p>
 
-                    {/* Action buttons in empty state - same as top buttons */}
                     <div className="mt-8 flex justify-center gap-4">
                         <button
                             onClick={openPostForm}

--- a/apps/web/src/pages/profile.tsx
+++ b/apps/web/src/pages/profile.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState, type ChangeEvent } from "react";
 import { useNavigate, useOutletContext, Link, useParams } from "react-router-dom";
-import { getProfile, updateProfile, uploadAvatar, getAvatarUrl } from "@campus-marketplace/backend";
+import { getAvatarUrl } from "@campus-marketplace/backend";
 import type { SessionUser } from "../features/types";
+import { useProfile, useUpdateProfile, useUploadAvatar } from "../hooks/useProfile";
 
 type OutletContext = {
     user: SessionUser | null;
@@ -14,7 +15,6 @@ export default function Profile() {
     const { user, onProfileSave } = useOutletContext<OutletContext>();
     const navigate = useNavigate();
     const [isEditing, setIsEditing] = useState(false);
-    const [refreshKey, setRefreshKey] = useState(0);
     const [accountTitle, setAccountTitle] = useState("Student Account");
     const [firstName, setFirstName] = useState("");
     const [lastName, setLastName] = useState("");
@@ -27,6 +27,11 @@ export default function Profile() {
     const [avatarError, setAvatarError] = useState("");
     const { userId: viewedUserId } = useParams<{ userId: string }>();
     const isOwner = !viewedUserId || viewedUserId === user?.id;
+
+    const { mutateAsync: updateProfileMutation } = useUpdateProfile();
+    const { mutateAsync: uploadAvatarMutation } = useUploadAvatar();
+    // Fetch the profile for whoever we're viewing (own profile or another user's).
+    const { data: profileData } = useProfile(viewedUserId ?? user?.id);
 
     const handleAvatarChange = (e: ChangeEvent<HTMLInputElement>) => {
         const file = e.target.files?.[0] || null;
@@ -84,32 +89,36 @@ export default function Profile() {
         return true;
     };
 
-    const loadProfile = async (userId: string) => {
-        try {
-            const profile = await getProfile(userId);
+    // Populate form fields whenever the cached profile data loads or changes.
+    // setState calls here are intentional — syncing server data into local form state.
+    useEffect(() => {
+        if (!profileData) return;
 
-            // Populate first/last name; fall back to splitting display_name for existing accounts.
-            if (profile.first_name) setFirstName(profile.first_name);
-            if (profile.last_name) setLastName(profile.last_name);
-            if (!profile.first_name && !profile.last_name && profile.display_name) {
-                const parts = profile.display_name.trim().split(/\s+/);
-                setFirstName(parts[0] ?? "");
-                setLastName(parts.slice(1).join(" "));
-            }
-
-            if (profile.bio !== null) setBio(profile.bio);
-            if (profile.avatar_path !== null) {
-                setAvatarUrl(`${getAvatarUrl(profile.avatar_path)}?t=${Date.now()}`);
-            }
-            if (profile.account_type === "student") {
-                setAccountTitle("Student");
-            } else if (profile.account_type === "business") {
-                setAccountTitle("Business");
-            }
-        } catch (error) {
-            console.error("Failed to load profile:", error);
+        /* eslint-disable react-hooks/set-state-in-effect */
+        if (profileData.first_name) setFirstName(profileData.first_name);
+        if (profileData.last_name) setLastName(profileData.last_name);
+        if (!profileData.first_name && !profileData.last_name && profileData.display_name) {
+            const parts = profileData.display_name.trim().split(/\s+/);
+            setFirstName(parts[0] ?? "");
+            setLastName(parts.slice(1).join(" "));
         }
-    };
+
+        if (profileData.bio !== null) setBio(profileData.bio);
+        if (profileData.avatar_path !== null) {
+            setAvatarUrl(`${getAvatarUrl(profileData.avatar_path)}?t=${Date.now()}`);
+        }
+        if (profileData.account_type === "student") {
+            setAccountTitle("Student");
+        } else if (profileData.account_type === "business") {
+            setAccountTitle("Business");
+        }
+        /* eslint-enable react-hooks/set-state-in-effect */
+    }, [profileData]);
+
+    useEffect(() => {
+        /* eslint-disable-next-line react-hooks/set-state-in-effect */
+        if (!viewedUserId && user?.email) setEmail(user.email);
+    }, [user, viewedUserId]);
 
     const saveProfile = async () => {
         if (!user) return;
@@ -128,7 +137,7 @@ export default function Profile() {
             let avatarPath: string | undefined;
 
             if (avatar) {
-                const updatedProfile = await uploadAvatar(user.id, avatar, avatar.type);
+                const updatedProfile = await uploadAvatarMutation({ userId: user.id, file: avatar, contentType: avatar.type });
                 avatarPath = updatedProfile.avatar_path ?? undefined;
                 if (updatedProfile.avatar_path) {
                     setAvatarUrl(`${getAvatarUrl(updatedProfile.avatar_path)}?t=${Date.now()}`);
@@ -137,27 +146,23 @@ export default function Profile() {
 
             const displayName = [firstName.trim(), lastName.trim()].filter(Boolean).join(" ");
 
-            await updateProfile(user.id, {
-                display_name: displayName,
-                first_name: firstName.trim() || null,
-                last_name: lastName.trim() || null,
-                bio,
-                ...(avatarPath ? { avatar_path: avatarPath } : {}),
+            await updateProfileMutation({
+                userId: user.id,
+                updates: {
+                    display_name: displayName,
+                    first_name: firstName.trim() || null,
+                    last_name: lastName.trim() || null,
+                    bio,
+                    ...(avatarPath ? { avatar_path: avatarPath } : {}),
+                },
             });
         } catch (error) {
             console.error("Failed to save profile:", error);
         }
 
         setIsEditing(false);
-        setRefreshKey((prev) => prev + 1);
         onProfileSave?.();
     };
-
-    useEffect(() => {
-        if (!user?.id) return;
-        if (!viewedUserId && user.email) setEmail(user.email);
-        void loadProfile(viewedUserId ?? user.id);
-    }, [user, refreshKey, viewedUserId]);
 
     const hasValidationErrors = Boolean(nameError || bioError || avatarError);
     const isSaveDisabled = isEditing && hasValidationErrors;

--- a/apps/web/src/pages/wishlist.tsx
+++ b/apps/web/src/pages/wishlist.tsx
@@ -1,15 +1,16 @@
-import { getListingImageUrl, getWishlist, removeFromWishlist } from "@campus-marketplace/backend";
+import { getListingImageUrl } from "@campus-marketplace/backend";
 import type { WishlistItemWithListing } from "@campus-marketplace/backend";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { Link, useLocation, useNavigate, useOutletContext } from "react-router-dom";
 import type { SessionUser } from "../features/types.ts";
+import { useWishlist, useRemoveFromWishlist } from "../hooks/useWishlist";
 
 type OutletContext = {
     user: SessionUser | null;
     openPostForm: () => void;
 };
 
-/** Badge label and color for each unavailability state. */
+/** Badge label for each unavailability state. */
 const UNAVAILABILITY_LABELS: Record<string, string> = {
     sold:     "Sold",
     closed:   "Closed",
@@ -21,14 +22,12 @@ export default function Wishlist() {
     const location = useLocation();
     const navigate = useNavigate();
     const { user } = useOutletContext<OutletContext>();
-    const [wishlistItems, setWishlistItems] = useState<WishlistItemWithListing[]>([]);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
+
+    const { data: wishlistItems = [], isLoading, error } = useWishlist(user?.id)
+    const { mutate: removeItem } = useRemoveFromWishlist()
 
     useEffect(() => {
         if (!user) {
-            // Only redirect if there are no stored tokens — if tokens exist,
-            // the session is still being restored asynchronously by the layout.
             const hasTokens = !!localStorage.getItem("access_token") && !!localStorage.getItem("refresh_token");
             if (!hasTokens) {
                 navigate("/login");
@@ -36,44 +35,9 @@ export default function Wishlist() {
         }
     }, [user, navigate]);
 
-    useEffect(() => {
-        if (!user) {
-            return;
-        }
-
-        const loadWishlist = async () => {
-            setLoading(true);
-            setError(null);
-            try {
-                const items = await getWishlist(user.id);
-                setWishlistItems(items);
-            }
-            catch (err) {
-                console.error("Failed to load wishlist:", err);
-                setError(err instanceof Error ? err.message : "Failed to load wishlist");
-            }
-            finally {
-                setLoading(false);
-            }
-        };
-
-        void loadWishlist();
-    }, [user]);
-
-    const handleRemove = async (wishlistItemId: string, listingId: string) => {
-        if (!user) {
-            return;
-        }
-
-        try {
-            await removeFromWishlist(user.id, listingId);
-            setWishlistItems(prev => prev.filter(i => i.id !== wishlistItemId));
-        }
-        catch {
-            // Optimistic removal failed — re-fetch to sync state.
-            const items = await getWishlist(user.id);
-            setWishlistItems(items);
-        }
+    const handleRemove = (_wishlistItemId: string, listingId: string) => {
+        if (!user) return;
+        removeItem({ userId: user.id, listingId });
     };
 
     return (
@@ -82,22 +46,24 @@ export default function Wishlist() {
                 <h1 className="mb-6 text-2xl font-bold">Your Wishlist</h1>
 
                 {error && (
-                    <p className="mb-4 rounded-lg bg-red-100 px-4 py-3 text-sm text-red-700">{error}</p>
+                    <p className="mb-4 rounded-lg bg-red-100 px-4 py-3 text-sm text-red-700">
+                        {error instanceof Error ? error.message : "Failed to load wishlist"}
+                    </p>
                 )}
 
-                {loading && wishlistItems.length > 0 && (
+                {isLoading && wishlistItems.length > 0 && (
                     <p className="mb-4 text-sm font-medium text-black/70">Updating wishlist...</p>
                 )}
 
-                {!loading && wishlistItems.length === 0 ? (
+                {!isLoading && wishlistItems.length === 0 ? (
                     <p>Your wishlist is empty.</p>
                 ) : wishlistItems.length > 0 ? (
                     <div className="relative grid grid-cols-1 gap-8 sm:grid-cols-2 xl:grid-cols-4">
-                        {loading && wishlistItems.length > 0 && (
+                        {isLoading && wishlistItems.length > 0 && (
                             <div className="pointer-events-none absolute inset-0 rounded-xl bg-white/20" aria-hidden="true" />
                         )}
 
-                        {wishlistItems.map((item) => {
+                        {wishlistItems.map((item: WishlistItemWithListing) => {
                             const listing = item.listing;
                             const isUnavailable = item.availability !== "available";
                             const unavailabilityLabel = UNAVAILABILITY_LABELS[item.availability];
@@ -108,7 +74,7 @@ export default function Wishlist() {
                                         type="button"
                                         aria-label="Remove from wishlist"
                                         className="absolute right-3 top-3 z-10 rounded-full border border-black/15 bg-white px-3 py-1 text-xs font-semibold text-black shadow-sm transition hover:opacity-85"
-                                        onClick={() => void handleRemove(item.id, item.listing_id)}
+                                        onClick={() => handleRemove(item.id, item.listing_id)}
                                     >
                                         Delete
                                     </button>

--- a/docs/CACHING.md
+++ b/docs/CACHING.md
@@ -1,0 +1,221 @@
+# Caching System
+
+This document explains how the app caches data, which parts of the app are affected, and how to work with the cache when adding new features.
+
+---
+
+## Overview
+
+The app uses **TanStack Query v5** (also known as React Query) as its caching layer. It runs entirely in the browser — the backend service layer is unchanged.
+
+TanStack Query wraps the existing async service functions and automatically:
+- Stores the result in memory after the first fetch
+- Serves that stored result instantly on repeat visits (while still "fresh")
+- Re-fetches in the background when data becomes "stale"
+- Invalidates (clears) entries when a mutation changes the data
+- Deduplicates requests — if two components ask for the same data at the same time, only one network call is made
+
+For the Messages page, polling every 15 seconds has been replaced with a **Supabase Realtime subscription** on the conversations table. When a conversation is updated, the cache is invalidated immediately instead of waiting for the next poll.
+
+---
+
+## How the Cache Lifecycle Works
+
+```
+First visit to a page:
+  → fetch from Supabase → store in cache → show to user
+
+Revisit within the stale window:
+  → serve from cache instantly (no network request)
+
+Revisit after the stale window:
+  → show cached data immediately (no spinner)
+  → fetch fresh data in background
+  → silently update the UI when fresh data arrives
+
+User takes a write action (add, edit, delete):
+  → write goes directly to Supabase
+  → on success, invalidate the relevant cache entry
+  → cache refetches and UI updates
+```
+
+**The cache lives in browser memory only.** A full page refresh (F5) clears it. This is intentional — a hard refresh means the user wants fresh data.
+
+---
+
+## Stale Times
+
+"Stale time" is how long a cached result is considered fresh before a background refetch is triggered.
+
+| Data | Stale Time | Reason |
+|---|---|---|
+| Browse listings (search results) | 5 min | Sellers don't update listings every few minutes |
+| My listings (own listings list) | 5 min | Only changes on create/publish/delete — cache is invalidated on those actions |
+| Listing detail (single listing page) | 5 min | Price/description edits are infrequent |
+| Own user profile | 10 min | Rarely changes mid-session |
+| Other user profiles (seller names on listing pages) | 10 min | Display names essentially never change |
+| Wishlist | 3 min | User-action driven; shorter window to feel responsive |
+| Conversations list (Messages sidebar) | 30 sec | Safety net only — Realtime subscription handles most updates instantly |
+| Messages (individual conversation) | 0 (always stale) | Realtime subscription keeps these live |
+| Categories | `Infinity` | Never changes (currently hardcoded anyway) |
+
+The app-wide default is **5 minutes** (set in `apps/web/src/main.tsx`). Each hook overrides this where needed.
+
+---
+
+## Query Key Conventions
+
+Every cached entry is identified by a **query key** — an array that uniquely names that data. This is how TanStack Query knows when two components want the same data, and what to invalidate after a mutation.
+
+```ts
+// Listings
+['listings', 'search', { query: 'bike', category_id: '...', limit: 12, offset: 0 }]
+['listings', 'detail', 'listing-uuid']
+['listings', 'byUser', 'user-uuid']
+
+// Profiles
+['profiles', 'user-uuid']
+
+// Wishlist
+['wishlists', 'user-uuid']
+
+// Conversations and messages
+['conversations', 'byUser', 'user-uuid']
+['conversations', 'messages', 'conversation-uuid']
+```
+
+The key factories are defined in each hook file:
+- `listingKeys` → `apps/web/src/hooks/useListings.ts`
+- `profileKeys` → `apps/web/src/hooks/useProfile.ts`
+- `wishlistKeys` → `apps/web/src/hooks/useWishlist.ts`
+- `conversationKeys` → `apps/web/src/hooks/useConversations.ts`
+
+---
+
+## Hook Reference
+
+### `useListings.ts`
+| Hook | What it fetches | Used in |
+|---|---|---|
+| `useSearchListings(filters)` | Paginated search results with full details | `index.tsx` |
+| `useListingDetail(id)` | Full details for one listing | `listing.tsx` |
+| `useListingsByUser(userId)` | All listings owned by a user (with details) | `my-listings.tsx` |
+| `useInvalidateListings()` | Returns helpers to invalidate listing caches | `listing.tsx` |
+
+### `useProfile.ts`
+| Hook | What it fetches | Used in |
+|---|---|---|
+| `useProfile(userId)` | Profile for any user (own or another user's) | `sidebar-layout.tsx`, `profile.tsx`, `my-listings.tsx`, `listing.tsx` |
+| `useUpdateProfile()` | Mutation: update profile fields | `profile.tsx` |
+| `useUploadAvatar()` | Mutation: upload a new avatar image | `profile.tsx` |
+
+### `useWishlist.ts`
+| Hook | What it fetches | Used in |
+|---|---|---|
+| `useWishlist(userId)` | Full wishlist with joined listing data | `wishlist.tsx`, `listing.tsx` |
+| `useIsWishlisted(userId, listingId)` | Boolean derived from wishlist cache — no extra DB call | `listing.tsx` |
+| `useAddToWishlist()` | Mutation: add listing to wishlist | `listing.tsx` |
+| `useRemoveFromWishlist()` | Mutation: remove listing from wishlist (optimistic) | `wishlist.tsx` |
+
+### `useConversations.ts`
+| Hook | What it fetches | Used in |
+|---|---|---|
+| `useConversations(userId)` | All conversations for a user | `messages.tsx` |
+| `useMessages(conversationId)` | Messages in one conversation | (available, currently kept as manual fetch in messages.tsx to preserve realtime integration) |
+| `useInvalidateConversations()` | Returns helper to invalidate conversation cache | `messages.tsx` |
+
+---
+
+## Cache Invalidation Rules
+
+After a mutation, the relevant cache entries are invalidated so the UI shows fresh data.
+
+| Action | What gets invalidated |
+|---|---|
+| Publish / unpublish a listing | `listingKeys.detail(id)`, `listingKeys.byUser(userId)` |
+| Delete a listing | `listingKeys.detail(id)`, `listingKeys.byUser(userId)`, `listingKeys.all` |
+| Add to wishlist | `wishlistKeys.byUser(userId)` |
+| Remove from wishlist | `wishlistKeys.byUser(userId)` (optimistic update applied first) |
+| Update profile | `profileKeys.detail(userId)` |
+| Upload avatar | `profileKeys.detail(userId)` |
+| Send message | `conversationKeys.byUser(userId)` |
+| Archive conversation | `conversationKeys.byUser(userId)` |
+| Conversation updated via Realtime | `conversationKeys.byUser(userId)` |
+
+---
+
+## Realtime + Cache Interaction
+
+The Messages page previously polled `getConversationsByUser()` every 15 seconds. At 10 conversations, that was 52+ database queries per poll.
+
+This has been replaced with a **Supabase Realtime subscription** (`subscribeToConversations` in `apps/backend/src/services/messaging.ts`). When any conversation the user is in is updated (new message sent, read status changed), the subscription fires and calls `invalidateConversations(userId)`, which triggers TanStack Query to refetch the conversation list.
+
+Individual message content (inside an open conversation) still uses the existing realtime subscription (`subscribeToMessages`) — unchanged.
+
+---
+
+## Adding a New Cached Query
+
+Follow this pattern to add caching to a new data type:
+
+**1. Create a hook file** in `apps/web/src/hooks/`:
+
+```ts
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { getMyData, updateMyData } from '@campus-marketplace/backend'
+
+// Centralised key factory so mutations can reference the same key.
+export const myDataKeys = {
+  all: ['myData'] as const,
+  detail: (id: string) => ['myData', id] as const,
+}
+
+// Read hook
+export function useMyData(id: string | undefined) {
+  return useQuery({
+    queryKey: myDataKeys.detail(id ?? ''),
+    queryFn: () => getMyData(id!),
+    staleTime: 5 * 60 * 1000, // choose based on how often data changes
+    enabled: !!id,
+  })
+}
+
+// Write hook
+export function useUpdateMyData() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, updates }: { id: string; updates: object }) =>
+      updateMyData(id, updates),
+    onSuccess: (_, { id }) => {
+      queryClient.invalidateQueries({ queryKey: myDataKeys.detail(id) })
+    },
+  })
+}
+```
+
+**2. Use it in your page** instead of a manual `useEffect`:
+
+```tsx
+// Before (no cache)
+const [data, setData] = useState(null)
+useEffect(() => {
+  getData(id).then(setData)
+}, [id])
+
+// After (cached)
+const { data, isLoading } = useMyData(id)
+```
+
+**3. Add the query key to this doc** so future devs know what keys exist.
+
+---
+
+## DevTools
+
+In development mode, a TanStack Query DevTools panel appears in the bottom-right corner of the app. Click it to see:
+- All active cache entries and their keys
+- Status of each query: `fresh`, `stale`, `fetching`, `error`
+- The cached data itself
+- When each entry was last fetched
+
+This is the fastest way to verify caching is working correctly.

--- a/docs/CACHING_EXPLAINED.md
+++ b/docs/CACHING_EXPLAINED.md
@@ -1,0 +1,475 @@
+# Caching — A Full Explanation
+
+This document explains what caching is, why we added it, how it works in this app specifically, and walks through every piece of code that was written to make it work. It is written for someone who understands React but has not worked with caching before.
+
+---
+
+## Part 1 — What is caching and why does it matter here?
+
+Every time a user opens a page in this app, the app asks the Supabase database for data. That round-trip — send a request, wait for the database to respond, receive the answer — takes time. On a fast connection it might be 100–300ms. On a slow one it can be a full second or more.
+
+Before caching was added, this happened on **every single page visit**, even if the data hadn't changed at all. Open the home page — fetch all listings. Click a listing — fetch it again. Go back to the home page — fetch all listings again. None of those previous answers were saved anywhere.
+
+Caching solves this by saving answers on the device after the first fetch. The next time the same data is needed, the saved copy is used instead of going to the database again.
+
+The benefit isn't just speed. The messaging page was also **polling** — asking the database "anything new?" on a repeating timer every 15 seconds. With 10 conversations open, that was 52+ database calls per minute, constantly, whether anything changed or not. Caching combined with real-time updates eliminated that entirely.
+
+---
+
+## Part 2 — The library we used: TanStack Query
+
+We use a library called **TanStack Query** (also called React Query) to manage the cache. You could write your own caching logic with `useState` and `useEffect`, but it would be hundreds of lines of code and easy to get wrong. TanStack Query handles all of it.
+
+Here is what it does automatically:
+
+- Saves the result of any database call in memory after the first fetch
+- Serves that saved result instantly on repeat visits (while it's still "fresh")
+- Re-fetches in the background when data becomes "stale" (more on stale times below)
+- Throws away a saved result when you tell it the data has changed (this is called **invalidation**)
+- Deduplicates requests — if two parts of the page ask for the same data at the same time, only one database call is made
+
+### What is a "stale time"?
+
+Every saved result has a freshness window. "Stale time" is how long the saved answer is considered current before the library decides it should ask the database for a newer copy.
+
+When data is within its stale time: serve from cache instantly, no database call.
+When data is past its stale time: show the saved copy immediately (no spinner), but also ask the database for fresh data in the background. When the new answer arrives, the page updates quietly.
+
+This means **the user never sees a blank page or a spinner caused by caching** — they always see something immediately.
+
+### What is a "query key"?
+
+Every saved result needs a label so the library can find it later. That label is called a **query key**. It's just an array of values that uniquely describes what was fetched.
+
+For example:
+- `["listings", "search", { limit: 12 }]` — the home page listings with no filters
+- `["listings", "search", { limit: 12, query: "bike" }]` — listings filtered by "bike"
+- `["listings", "detail", "abc-123"]` — the full details for one specific listing
+- `["profiles", "user-uuid-here"]` — one user's profile
+- `["wishlists", "user-uuid-here"]` — one user's wishlist
+
+Two different filters = two different query keys = two separate saved results. The library knows they're different things.
+
+### What is "invalidation"?
+
+When you do something that changes data — like removing a listing from your wishlist — the saved copy of your wishlist is now wrong. **Invalidation** is how you tell the library "throw away that entry." The next time anything reads that data, it will fetch fresh from the database.
+
+---
+
+## Part 3 — Setup: `apps/web/src/main.tsx`
+
+Before any caching works, TanStack Query needs to be set up once at the top of the app. This is done in `main.tsx`, which is the very first file that runs when the app starts.
+
+```tsx
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60 * 1000,  // 5 minutes in milliseconds
+      gcTime: 15 * 60 * 1000,    // 15 minutes
+      refetchOnWindowFocus: true,
+      retry: 1,
+    },
+  },
+})
+```
+
+**What each line means:**
+
+`new QueryClient(...)` — creates the cache itself. Think of this as creating the notepad that all saved results get written to.
+
+`staleTime: 5 * 60 * 1000` — the default freshness window is 5 minutes. Any data fetched will be considered current for 5 minutes before a background re-fetch is triggered. Individual hooks override this where needed (the wishlist uses 3 minutes, profiles use 10 minutes, etc.).
+
+`gcTime: 15 * 60 * 1000` — "gc" stands for garbage collection. This controls how long an unused saved result stays in memory after nothing in the app is reading it anymore. If you leave the messages page and come back 14 minutes later, the conversation list is still in memory and loads instantly. After 15 minutes of not being read, it's cleared out to free up memory.
+
+`refetchOnWindowFocus: true` — if the user switches to a different browser tab and then comes back, the library will quietly re-check any stale data. This is how data stays reasonably current even if someone has the app open in the background for a long time.
+
+`retry: 1` — if a database call fails (network hiccup, temporary error), try once more before giving up.
+
+```tsx
+<QueryClientProvider client={queryClient}>
+  <App />
+  <ReactQueryDevtools initialIsOpen={false} />
+</QueryClientProvider>
+```
+
+`QueryClientProvider` wraps the entire app so that every component inside it can access the cache. This is the same pattern React uses for themes and authentication — a "provider" makes something available to the whole tree.
+
+`ReactQueryDevtools` adds the floating panel in the bottom-right corner of the app (development only). It shows every saved result, its label, its current status (fresh / stale / loading / error), and the actual data inside it. This is the fastest way to confirm caching is working.
+
+---
+
+## Part 4 — The hook files
+
+A **hook** in React is a function whose name starts with `use`. Hooks let components access shared logic and state. We created four hook files, one per area of the app. Each file contains:
+
+1. A **query key factory** — a consistent way to generate the label for that type of data
+2. One or more **read hooks** (`useQuery` or `useInfiniteQuery`) — these fetch and cache data
+3. Zero or more **mutation hooks** (`useMutation`) — these write data and then invalidate the relevant cache entries
+
+---
+
+### `apps/web/src/hooks/useListings.ts`
+
+This file handles everything related to listings.
+
+#### Query key factory
+
+```ts
+export const listingKeys = {
+  all: ['listings'] as const,
+  search: (filters: object) => ['listings', 'search', filters] as const,
+  detail: (id: string) => ['listings', 'detail', id] as const,
+  byUser: (userId: string) => ['listings', 'byUser', userId] as const,
+}
+```
+
+`listingKeys.all` — a label that covers every listing-related cache entry. Invalidating this throws away all saved listing data at once (used when deleting a listing, since it could affect any search result page).
+
+`listingKeys.search(filters)` — a label for one specific set of search results. If filters change, the label changes, and the library knows to fetch new results rather than serve the old ones.
+
+`listingKeys.detail(id)` — a label for one specific listing's full details. Each listing gets its own entry.
+
+`listingKeys.byUser(userId)` — a label for all listings owned by one user.
+
+The reason this is a centralized factory (instead of just writing the arrays directly in each hook) is so that when a mutation needs to invalidate a cache entry, it uses the exact same label the read hook used. If they don't match perfectly, the invalidation silently does nothing.
+
+#### `useSearchListings` — the home page listings
+
+```ts
+export function useSearchListings(filters: {
+  query?: string
+  category_id?: string
+  type?: 'item' | 'service'
+  limit: number
+}) {
+  return useInfiniteQuery({
+    queryKey: listingKeys.search(filters),
+    queryFn: async ({ pageParam }) => {
+      const results = await searchListings({ ...filters, offset: pageParam as number })
+      const detailed = await Promise.all(
+        results.map((listing) => getListingWithDetails(listing.id)),
+      )
+      return { listings: detailed, hasMore: results.length === filters.limit }
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.hasMore ? allPages.length * filters.limit : undefined,
+    staleTime: LISTINGS_STALE_TIME,
+  })
+}
+```
+
+This uses `useInfiniteQuery` instead of the regular `useQuery`. The difference:
+
+- `useQuery` — fetches one page of results and caches it
+- `useInfiniteQuery` — fetches results in pages and caches **all pages together** under one label
+
+This matters for the home page infinite scroll. When the user scrolls down and loads page 2, page 3, etc., those all get stored alongside page 1. If they navigate to the messages page and come back, all the pages they had already loaded are still there — they don't have to re-scroll to reload them.
+
+`pageParam` is a number that starts at 0 and increases by `limit` (12) each page. The library manages this automatically.
+
+`getNextPageParam` — after each page loads, this function decides what the next page offset should be. If the last page returned 12 results (a full page), there's probably more — return the next offset. If it returned fewer than 12, we're at the end — return `undefined` to stop.
+
+`hasMore: results.length === filters.limit` — a simple way to detect "are there more pages?" If we asked for 12 and got 12, there might be more. If we got 11 or fewer, we've hit the end.
+
+#### `useListingDetail` — a single listing page
+
+```ts
+export function useListingDetail(id: string | undefined) {
+  return useQuery({
+    queryKey: listingKeys.detail(id ?? ''),
+    queryFn: () => getListingWithDetails(id!),
+    staleTime: LISTINGS_STALE_TIME,
+    enabled: !!id,
+  })
+}
+```
+
+`enabled: !!id` — this prevents the hook from running if `id` is undefined or an empty string. The `!!` converts a value to `true` or `false` (two exclamation marks = double negative = "is this truthy?"). Without this guard, the hook would try to fetch a listing with no ID the moment the component mounts, before the URL parameter is available.
+
+#### `useInvalidateListings` — helpers to throw away cached listings
+
+```ts
+export function useInvalidateListings() {
+  const queryClient = useQueryClient()
+  return {
+    invalidateAll: () =>
+      queryClient.invalidateQueries({ queryKey: listingKeys.all }),
+    invalidateDetail: (id: string) =>
+      queryClient.invalidateQueries({ queryKey: listingKeys.detail(id) }),
+    invalidateByUser: (userId: string) =>
+      queryClient.invalidateQueries({ queryKey: listingKeys.byUser(userId) }),
+  }
+}
+```
+
+`useQueryClient()` gives a component access to the cache itself so it can call operations on it directly (like invalidation).
+
+`invalidateQueries` marks a cache entry as stale immediately, which triggers a re-fetch the next time anything reads it. The `queryKey` you pass in acts as a filter — it will invalidate every saved result whose label starts with those values.
+
+---
+
+### `apps/web/src/hooks/useProfile.ts`
+
+```ts
+export function useProfile(userId: string | undefined) {
+  return useQuery({
+    queryKey: profileKeys.detail(userId ?? ''),
+    queryFn: () => getProfile(userId!),
+    staleTime: PROFILE_STALE_TIME, // 10 minutes
+    enabled: !!userId,
+  })
+}
+```
+
+The key insight here: `useProfile` is called in four separate places — the sidebar (to show the avatar), the profile page, the my-listings page, and the listing detail page (to show the seller's name). Before caching, each of those locations would fire its own separate database call. Now they all use the same label `["profiles", userId]`, so the first one to call it fetches from the database, and the other three read from the saved copy instantly.
+
+#### `useUpdateProfile` and `useUploadAvatar` — write hooks
+
+```ts
+export function useUpdateProfile() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ userId, updates }) => updateProfile(userId, updates),
+    onSuccess: (_, { userId }) => {
+      queryClient.invalidateQueries({ queryKey: profileKeys.detail(userId) })
+    },
+  })
+}
+```
+
+`useMutation` is TanStack Query's hook for write operations (creating, updating, deleting). Unlike `useQuery`, it doesn't run automatically — it runs when you call `mutate(...)` or `mutateAsync(...)`.
+
+`mutationFn` — the actual database call to make.
+
+`onSuccess` — runs after the database call succeeds. Here, it invalidates the cached profile for that user, so the sidebar avatar and profile page both re-fetch the updated data automatically.
+
+---
+
+### `apps/web/src/hooks/useWishlist.ts`
+
+#### `useIsWishlisted` — no extra database call
+
+```ts
+export function useIsWishlisted(userId: string | undefined, listingId: string | undefined) {
+  const { data: wishlist } = useWishlist(userId)
+  if (!userId || !listingId || !wishlist) return false
+  return wishlist.some((item) => item.listing_id === listingId)
+}
+```
+
+Before caching, when a user opened a listing page, the app would make a separate database call just to answer the question "is this in their wishlist?" — a single yes/no question that cost a round-trip to the database.
+
+Now, because the wishlist is already cached under `["wishlists", userId]`, this hook just looks through that saved data and returns the answer without touching the database. The wishlist is pre-loaded when the listing page mounts via `useWishlist(user?.id)`.
+
+#### `useRemoveFromWishlist` — optimistic updates
+
+```ts
+export function useRemoveFromWishlist() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ userId, listingId }) => removeFromWishlist(userId, listingId),
+    onMutate: async ({ userId, listingId }) => {
+      await queryClient.cancelQueries({ queryKey: wishlistKeys.byUser(userId) })
+      const previous = queryClient.getQueryData(wishlistKeys.byUser(userId))
+      queryClient.setQueryData(wishlistKeys.byUser(userId), (old) =>
+        old ? old.filter((item) => item.listing_id !== listingId) : old,
+      )
+      return { previous, userId }
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(wishlistKeys.byUser(context.userId), context.previous)
+      }
+    },
+    onSettled: (_data, _err, { userId }) => {
+      queryClient.invalidateQueries({ queryKey: wishlistKeys.byUser(userId) })
+    },
+  })
+}
+```
+
+This is the most complex piece of code in the caching system. It uses **optimistic updates** — a technique where you update the UI immediately as if the operation succeeded, then confirm with the database in the background.
+
+Step by step:
+
+`onMutate` — runs *before* the database call.
+- `cancelQueries` — stops any in-progress fetch for the wishlist. If the cache was in the middle of loading and we didn't stop it, the result that comes back would overwrite the change we're about to make.
+- `getQueryData` — reads a snapshot of the current wishlist from the cache. This snapshot is the "rollback point."
+- `setQueryData` — directly writes a modified version into the cache. Here, it filters out the item being removed. The wishlist page instantly shows the item as gone.
+- `return { previous, userId }` — saves the snapshot so we can use it in case of error.
+
+`onError` — runs if the database call fails.
+- `setQueryData` with `context.previous` — puts the original wishlist back into the cache, undoing the change. The item re-appears on the page.
+
+`onSettled` — runs after the database call finishes, whether it succeeded or failed.
+- `invalidateQueries` — regardless of what happened, ask the database for the real current state of the wishlist and update the cache with the truth.
+
+The result: clicking "Delete" on a wishlist item feels instant. The item disappears the moment you click. If the network was down and the delete actually failed, it would reappear.
+
+---
+
+### `apps/web/src/hooks/useConversations.ts`
+
+```ts
+export function useConversations(userId: string | undefined) {
+  return useQuery({
+    queryKey: conversationKeys.byUser(userId ?? ''),
+    queryFn: () => getConversationsByUser(userId!),
+    staleTime: CONVERSATIONS_STALE_TIME, // 30 seconds
+    enabled: !!userId,
+  })
+}
+```
+
+The stale time here is only 30 seconds instead of 5 minutes. This is a safety net — the real reason updates are fast is the real-time subscription described below.
+
+#### `useInvalidateConversations`
+
+```ts
+export function useInvalidateConversations() {
+  const queryClient = useQueryClient()
+  return {
+    invalidate: (userId: string) =>
+      queryClient.invalidateQueries({ queryKey: conversationKeys.byUser(userId) }),
+  }
+}
+```
+
+This is called from the messages page every time something changes — a new message arrives, a message is sent, a conversation is archived. Instead of updating an array in local state manually, it just throws away the cached conversation list and lets TanStack Query re-fetch it cleanly.
+
+---
+
+## Part 5 — How the pages changed
+
+### Home page (`index.tsx`)
+
+Before: a `useEffect` ran on every page visit, set a loading spinner, called the database, and set the results into local state. Every time you left and came back — even if nothing had changed — it started over from zero.
+
+After:
+
+```tsx
+const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } = useSearchListings(filters);
+const listingsData = data?.pages.flatMap((page) => page.listings) ?? [];
+```
+
+`data?.pages` — TanStack Query stores infinite query results as an array of pages. Each element is one page of listings (up to 12). `flatMap` flattens that into one single array of all listings loaded so far.
+
+`fetchNextPage` — instead of manually tracking an offset number in state and incrementing it, the library manages pagination for you. Calling `fetchNextPage()` fetches the next page and appends it to `data.pages`.
+
+The IntersectionObserver (which watches for the "load more" sentinel element scrolling into view) now calls `fetchNextPage()` instead of incrementing a counter.
+
+---
+
+### Listing page (`listing.tsx`)
+
+Before: one large `useEffect` that called `getListingWithDetails`, `getProfile`, and `isWishlisted` every time the component mounted.
+
+After:
+
+```tsx
+const { data: listingData, refetch: refetchListing } = useListingDetail(id);
+const { data: sellerProfile } = useProfile(listingData?.user_id);
+const isInWishlist = useIsWishlisted(user?.id, listingData?.id);
+useWishlist(user?.id); // pre-load the wishlist so useIsWishlisted can read from it
+```
+
+`useProfile(listingData?.user_id)` — fetches the seller's profile using the same cache entry that is also used if you visited their profile page. If you had already looked at their profile, this costs zero database calls.
+
+`refetch: refetchListing` — used after publishing or unpublishing a listing to immediately re-fetch the latest status. Combined with invalidation, this ensures the publish button label updates right away.
+
+**Wishlist toggle fix:** The original code called `invalidateAll()` after toggling the wishlist — but `invalidateAll()` only clears listing caches, not the wishlist cache. The heart icon would stay wrong until the 3-minute freshness window expired. Fixed to:
+
+```tsx
+void queryClient.invalidateQueries({ queryKey: wishlistKeys.byUser(user.id) });
+```
+
+This clears the right cache entry — the wishlist — so the heart icon updates immediately.
+
+---
+
+### Messages page (`messages.tsx`) — replacing polling with real-time
+
+Before: a `setInterval` ran every 15 seconds and called `getConversationsByUser`. With 10 conversations, that function fires 2 + 5×10 = 52 database queries per call. Every 15 seconds. That's over 200 database calls per minute just to check for new messages.
+
+The old code:
+```ts
+// Called every 15 seconds — very expensive
+const interval = setInterval(async () => {
+  const updatedConvos = await getConversationsByUser(user.id)
+  setConversations(updatedConvos)
+}, 15000)
+```
+
+After: the polling is completely removed. Instead, the app subscribes to real-time changes directly from Supabase:
+
+```tsx
+useEffect(() => {
+  if (!user || conversations.length === 0) return;
+
+  const conversationIds = conversations.map((c) => c.id);
+  const { unsubscribe } = subscribeToConversations(conversationIds, () => {
+    invalidateConversations(user.id);
+  });
+
+  return unsubscribe;
+}, [user?.id, conversations.length]);
+```
+
+`subscribeToConversations` — a function in the backend service layer that opens a persistent connection to Supabase. Supabase sends a notification the moment any of those conversations are updated (new message, read status changed). The callback function `() => invalidateConversations(user.id)` runs immediately when that notification arrives.
+
+`invalidateConversations(user.id)` — throws away the cached conversation list and re-fetches it. One database call, triggered by an actual event, instead of 52 calls every minute on a timer.
+
+`return unsubscribe` — when the user navigates away from the messages page, React runs this cleanup function to close the real-time connection so it doesn't keep running in the background.
+
+---
+
+### Sidebar (`sidebar-layout.tsx`)
+
+Before: a `useEffect` called `getProfile(user.id)` and saved the result in a local `profile` state variable.
+
+After:
+
+```tsx
+const { data: profile } = useProfile(user?.id);
+```
+
+One line. The sidebar now reads from the same shared cache entry as the profile page and my-listings page. The first one to request it fetches from the database; the rest read instantly from the saved copy.
+
+---
+
+## Part 6 — How all the freshness windows were chosen
+
+| Area | Fresh for | Reasoning |
+|---|---|---|
+| Home page listings | 5 minutes | Sellers don't post and edit listings every few seconds. A 5-minute window means a user browsing for 10 minutes won't trigger unnecessary re-fetches, but a new listing will show up within a reasonable time. |
+| A single listing | 5 minutes | Same reasoning. The cache is also thrown away immediately if the owner edits, publishes, or deletes it. |
+| Your own listings | 5 minutes | Cache is invalidated the moment you create, delete, or publish one, so the 5-minute window rarely matters in practice. |
+| Your profile | 10 minutes | You're very unlikely to change your name or bio in the middle of a session. 10 minutes is safe and reduces database load on the profile page, sidebar, and my-listings simultaneously. |
+| Another user's profile | 10 minutes | Display names essentially never change. Shared with the same `useProfile` hook. |
+| Wishlist | 3 minutes | You're actively clicking add/remove, so the freshness window is shorter to keep it feeling responsive. Actions also invalidate the cache immediately, so the window mainly matters for passive viewing. |
+| Conversation list | 30 seconds | Short safety net. Real-time updates from Supabase handle instant changes; the 30-second window ensures that if the real-time connection drops for any reason, data is still re-fetched quickly. |
+| Individual messages | 0 (never fresh) | Always re-fetched when an active conversation is opened. The real-time subscription (`subscribeToMessages`) handles everything after that. |
+
+---
+
+## Part 7 — The developer tools panel
+
+In development, a small icon appears in the bottom-right corner of the app. Clicking it opens the TanStack Query DevTools panel. This shows:
+
+- Every cache entry and its label (query key)
+- Whether it is **fresh** (within the stale time), **stale** (past the stale time but still in memory), **fetching** (a database call is in progress), or **error**
+- The actual data saved inside each entry
+- How long ago it was last fetched
+
+To verify caching is working: load the home page, open DevTools, confirm `["listings","search",{"limit":12}]` shows as **fresh**. Navigate to Messages and back. If it still shows **fresh** and no new network requests appear in the browser's Network tab, the cache is working correctly.
+
+---
+
+## Part 8 — What did not change
+
+The database layer (`apps/backend/src/services/`) was not touched. The service functions (`getListingWithDetails`, `getProfile`, `getConversationsByUser`, etc.) work exactly as before. The cache sits entirely in the frontend and wraps those existing functions — it doesn't know or care how they work internally.
+
+No database schema changes. No migrations. No new Supabase tables.
+
+The existing real-time subscriptions for individual messages (`subscribeToMessages`) and notifications (`subscribeToNotifications`) were also left untouched.

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@campus-marketplace/backend": "*",
+        "@tanstack/react-query": "^5.99.0",
+        "@tanstack/react-query-devtools": "^5.99.0",
         "lucide-react": "^1.8.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -2202,6 +2204,59 @@
         "@tailwindcss/oxide": "4.2.1",
         "postcss": "^8.5.6",
         "tailwindcss": "4.2.1"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.0.tgz",
+      "integrity": "sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.99.0.tgz",
+      "integrity": "sha512-m4ufXaJ8FjWXw7xDtyzE/6fkZAyQFg9WrbMrUpt8ZecRJx58jiFOZ2lxZMphZdIpAnIeto/S8stbwLKLusyckQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.0.tgz",
+      "integrity": "sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.99.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.99.0.tgz",
+      "integrity": "sha512-CqqX7LCU9yOfCY/vBURSx2YSD83ryfX+QkfkaKionTfg1s2Hdm572Ro99gW3QPoJjzvsj1HM4pnN4nbDy3MXKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.99.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.99.0",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tybys/wasm-util": {


### PR DESCRIPTION
## Caching Layer — TanStack Query + Realtime Replacement for Polling                                                                                    
  
  ### What this PR does                                                                                                                                      
  Adds a client-side caching layer across the entire frontend using TanStack Query v5. Before this, every page visit fired fresh database calls regardless of whether the data had changed. The messages page was also polling the database every 15 seconds (52+ queries per minute at 10 conversations). Both problems are fixed here.

  ---

  ### New files

  **`apps/web/src/hooks/useListings.ts`**
  Caching hooks for all listing data. Contains `useSearchListings` (infinite scroll with all pages cached together), `useListingDetail` (single listing), `useListingsByUser` (own listings), and `useInvalidateListings` (helpers to clear listing caches after mutations like publish, delete, and edit).  5-minute stale time.

  **`apps/web/src/hooks/useProfile.ts`**
  Caching hook for user profiles. `useProfile(userId)` works for both the logged-in user and any other user (e.g. seller on a listing page). The same cache entry is shared by the sidebar, profile page, my-listings, and listing detail — the database is only called once no matter how many of those are mounted at the same time. Also contains `useUpdateProfile` and `useUploadAvatar` mutations that invalidate the profile cache on success. 10-minute stale time.

  **`apps/web/src/hooks/useWishlist.ts`**
  Caching hooks for the wishlist. `useWishlist` fetches and caches the full wishlist. `useIsWishlisted` derives a true/false answer from the cached       
  wishlist with no extra database call. `useRemoveFromWishlist` uses an optimistic update — the item disappears from the UI immediately on click and      
  reappears only if the database call fails. 3-minute stale time.

  **`apps/web/src/hooks/useConversations.ts`**
  Caching hooks for the messages page. `useConversations` caches the conversation list with a 30-second stale time as a safety net.
  `useInvalidateConversations` returns a helper used by the realtime subscription to clear the cache when a conversation updates. `useMessages` is        
  included for future use.

  **`docs/CACHING.md`**
  Technical reference for the caching system. Covers stale times per data type, query key naming conventions, which hooks are used on which pages, cache  
  invalidation rules, and how the realtime subscription replaced polling.

  **`docs/CACHING_EXPLAINED.md`**
  Plain-language walkthrough of the entire caching system written for developers new to the concept. Explains every hook, every code change, and every    
  design decision without assuming prior knowledge of TanStack Query.

  ---

  ### Modified files

  **`apps/web/src/main.tsx`**
  Added `QueryClient` with global defaults (5-minute stale time, 15-minute memory window, refetch on tab focus, 1 retry on failure), `QueryClientProvider`
   wrapping the app, and `ReactQueryDevtools` for the development panel.

  **`apps/web/src/pages/index.tsx`**
  Replaced the manual `useEffect` fetch with `useSearchListings`. Infinite scroll now uses `useInfiniteQuery` — all loaded pages are cached together so   
  navigating away and back shows them instantly. The IntersectionObserver calls `fetchNextPage()` instead of manually tracking an offset.

  **`apps/web/src/pages/listing.tsx`**
  Replaced manual `useEffect` fetches for listing data, seller profile, and wishlist status with `useListingDetail`, `useProfile`, and `useIsWishlisted`. 
  Publish, unpublish, and delete actions now call the appropriate cache invalidation helpers. Fixed a bug where toggling the wishlist was invalidating the
   listings cache instead of the wishlist cache, causing the heart icon to stay in the wrong state until the stale time expired.

  **`apps/web/src/pages/my-listings.tsx`**
  Replaced manual fetch + state management with `useListingsByUser` and `useProfile`. Removed all loading state and useEffect boilerplate.

  **`apps/web/src/pages/profile.tsx`**
  Replaced `getProfile`, `updateProfile`, and `uploadAvatar` direct calls with `useProfile`, `useUpdateProfile`, and `useUploadAvatar` hooks. Form fields 
  are populated via a `useEffect` that syncs server data into local form state when the cached profile loads.

  **`apps/web/src/pages/wishlist.tsx`**
  Replaced manual fetch + state management with `useWishlist` and `useRemoveFromWishlist`. Removing an item is now optimistic — the UI updates before the 
  server confirms.

  **`apps/web/src/pages/messages.tsx`**
  Removed the 15-second `setInterval` polling entirely. Replaced with `useConversations` for cached data and a `subscribeToConversations` realtime        
  subscription that invalidates the cache the moment a conversation updates. This drops from 52+ database queries per minute to one query per actual      
  event.

  **`apps/web/src/layouts/sidebar-layout.tsx`**
  Replaced manual `getProfile` call with `useProfile(user?.id)`. The sidebar now shares the same cache entry as the profile page — no duplicate fetches.  

  **`apps/backend/src/services/messaging.ts`**
  Added `subscribeToConversations(conversationIds, onChange)` — a new exported function that opens a Supabase Realtime subscription on the conversations  
  table and fires a callback when any of the given conversations are updated. Used by the messages page to replace polling.

  **`apps/backend/src/services/__tests__/messaging.test.ts`**
  Fixed a pre-existing TypeScript error where `"c-new"` was used as a mock UUID value but did not satisfy the UUID type constraint. Replaced all
  occurrences with a valid UUID format.

  **`apps/web/src/features/page-header.tsx`**
  Removed an unused `Bookmark` import that was causing a lint error.