### PR TITLE
Feat/lisitng archive

### DIFF
--- a/apps/backend/src/services/__tests__/listings.test.ts
+++ b/apps/backend/src/services/__tests__/listings.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createClient } from "@supabase/supabase-js";
+import { config as loadEnv } from "dotenv";
+import { resolve } from "node:path";
+import { createConversation, sendMessage, ConversationLockedError } from "../messaging.js";
 import {
   createListing,
   deleteListingImage,
@@ -6,6 +10,8 @@ import {
   getListingImageUrl,
   getListingPublishReadiness,
   ListingPublishValidationError,
+  markListingAsSold,
+  ListingAlreadySoldError,
   publishListing,
   updateListing,
   deleteListing,
@@ -22,12 +28,62 @@ import { createTestUser, createTestListing } from "./helpers.js";
 import type { TestUser } from "./helpers.js";
 
 let testUser: TestUser;
+// secondUser is created via the admin API to avoid consuming an extra auth signup
+// quota slot and to avoid overwriting the shared client's session.
+let secondUser: TestUser;
+// Separate Supabase client for secondUser — using the anon key so we can
+// authenticate as secondUser without touching the shared service-key client.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let secondUserClient: ReturnType<typeof createClient<any>>;
 let categoryId: string;
 const listingIdsToCleanup: string[] = [];
 const imageCleanup: Array<{ imageId: string; userId: string }> = [];
 
 beforeAll(async () => {
   testUser = await createTestUser("Listings Test User");
+
+  // Create a second user via the admin API — no signUpWithEmail call, so the shared
+  // service-key client's auth session remains as testUser's JWT.
+  const secondEmail = `test-second-${Date.now()}@test.edu`;
+  const secondPassword = "TestPassword123!";
+  const { data: adminData, error: adminError } = await supabase.auth.admin.createUser({
+    email: secondEmail,
+    password: secondPassword,
+    email_confirm: true,
+    user_metadata: { display_name: "Second Test User" },
+  });
+  if (adminError || !adminData.user) {
+    throw new Error(`Failed to create second test user: ${adminError?.message ?? "unknown"}`);
+  }
+
+  // Build a separate anon-key client for secondUser so wishlists/notifications can
+  // be inserted as secondUser (RLS checks auth.uid() = user_id on those tables).
+  // The anon key lives in apps/web/.env.local as VITE_SUPABASE_ANON_KEY.
+  loadEnv({ path: resolve(process.cwd(), "../web/.env.local") });
+  const supabaseUrl = process.env["SUPABASE_URL"] ?? "";
+  const supabaseAnonKey = process.env["SUPABASE_ANON_KEY"] ?? process.env["VITE_SUPABASE_ANON_KEY"] ?? "";
+  secondUserClient = createClient(supabaseUrl, supabaseAnonKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { error: signInError } = await secondUserClient.auth.signInWithPassword({
+    email: secondEmail,
+    password: secondPassword,
+  });
+  if (signInError) {
+    throw new Error(`Failed to sign in second test user: ${signInError.message}`);
+  }
+
+  secondUser = {
+    user: adminData.user,
+    session: null,
+    cleanup: async () => {
+      try {
+        await supabase.auth.admin.deleteUser(adminData.user.id);
+      } catch {
+        // Ignore cleanup errors
+      }
+    },
+  };
 
   const { data: existingCategory, error: categoryLookupError } = await supabase
     .from("categories")
@@ -79,6 +135,7 @@ afterAll(async () => {
     }
   }
   await testUser.cleanup();
+  await secondUser?.cleanup();
 });
 
 function trackListing(id: string) {
@@ -576,5 +633,134 @@ describe("listing image storage", () => {
     await expect(
       deleteListingImage(uploaded.id, "00000000-0000-0000-0000-000000000000"),
     ).rejects.toThrow("permission");
+  });
+});
+
+describe("markListingAsSold", () => {
+  it("sets status to sold and removes listing from public search", async () => {
+    const listing = await createPublishableDraft(testUser.user.id);
+    await publishListing(listing.id, testUser.user.id);
+
+    const sold = await markListingAsSold(listing.id, testUser.user.id);
+
+    expect(sold.status).toBe("sold");
+
+    // Should no longer appear in public search
+    const results = await searchListings({});
+    expect(results.some((l) => l.id === listing.id)).toBe(false);
+
+    // Seller can still see it
+    const sellerListings = await getListingsByUser(testUser.user.id);
+    expect(sellerListings.some((l) => l.id === listing.id)).toBe(true);
+  });
+
+  it("throws ListingAlreadySoldError if already sold", async () => {
+    const listing = await createTestListing(testUser.user.id, {
+      title: "Already Sold Listing",
+    });
+    trackListing(listing.id);
+    await supabase.from("listings").update({ status: "sold" }).eq("id", listing.id);
+
+    await expect(markListingAsSold(listing.id, testUser.user.id)).rejects.toBeInstanceOf(
+      ListingAlreadySoldError,
+    );
+  });
+
+  it("throws when called by a non-owner", async () => {
+    const listing = await createTestListing(testUser.user.id, {
+      title: "Other Owner Listing",
+    });
+    trackListing(listing.id);
+
+    await expect(markListingAsSold(listing.id, secondUser.user.id)).rejects.toThrow("permission");
+  });
+
+  it("creates listing_sold notifications for wishlisted users", async () => {
+    const listing = await createPublishableDraft(testUser.user.id, {
+      title: "Wishlisted Item",
+    });
+
+    // Insert wishlist as secondUser — uses the per-user anon client so auth.uid()
+    // matches user_id and the RLS policy is satisfied.
+    const { error: wishlistError } = await secondUserClient.from("wishlists").insert({
+      user_id: secondUser.user.id,
+      listing_id: listing.id,
+    });
+    if (wishlistError) throw new Error(`Wishlist insert failed: ${wishlistError.message}`);
+
+    // Sign out of testUser's session so the shared client uses the service role key.
+    // This allows markListingAsSold's internal wishlist query to bypass RLS and see
+    // all wishlist entries (not just testUser's). The service role JWT bypasses all RLS.
+    await supabase.auth.signOut();
+    await markListingAsSold(listing.id, testUser.user.id);
+    // Sign back in as testUser for the notification assertions below.
+    if (testUser.session) {
+      await supabase.auth.setSession({
+        access_token: testUser.session.access_token,
+        refresh_token: testUser.session.refresh_token,
+      });
+    }
+
+    // Query notifications as secondUser (RLS scopes notifications to auth.uid() = user_id)
+    const { data: notifications } = await secondUserClient
+      .from("notifications")
+      .select("*")
+      .eq("user_id", secondUser.user.id)
+      .eq("type", "listing_sold")
+      .eq("payload->>listing_id", listing.id);
+
+    expect(notifications?.length).toBeGreaterThanOrEqual(1);
+    expect(notifications![0].payload.listing_title).toBe("Wishlisted Item");
+
+    // Cleanup — use secondUserClient for rows owned by secondUser
+    await secondUserClient.from("wishlists").delete().eq("listing_id", listing.id);
+    await secondUserClient.from("notifications").delete().eq("payload->>listing_id", listing.id);
+  });
+
+  it("does not create a notification for the seller", async () => {
+    const listing = await createPublishableDraft(testUser.user.id, {
+      title: "Seller No Notify",
+    });
+
+    // Seller wishlists their own listing (edge case)
+    await supabase.from("wishlists").insert({
+      user_id: testUser.user.id,
+      listing_id: listing.id,
+    });
+
+    await markListingAsSold(listing.id, testUser.user.id);
+
+    const { data: notifications } = await supabase
+      .from("notifications")
+      .select("*")
+      .eq("user_id", testUser.user.id)
+      .eq("type", "listing_sold")
+      .eq("payload->>listing_id", listing.id);
+
+    expect(notifications?.length ?? 0).toBe(0);
+
+    // Cleanup
+    await supabase.from("wishlists").delete().eq("listing_id", listing.id);
+  });
+
+  it("blocks sendMessage after listing is marked sold", async () => {
+    const listing = await createPublishableDraft(testUser.user.id, {
+      title: "Soon To Be Sold",
+    });
+
+    // Create a conversation between testUser (seller) and secondUser (buyer)
+    const conversation = await createConversation(
+      secondUser.user.id,
+      testUser.user.id,
+      listing.id,
+    );
+
+    // Mark it sold
+    await markListingAsSold(listing.id, testUser.user.id);
+
+    // Buyer tries to send a message — should be blocked
+    await expect(
+      sendMessage(conversation.id, secondUser.user.id, "Is this still available?"),
+    ).rejects.toBeInstanceOf(ConversationLockedError);
   });
 });

--- a/apps/backend/src/services/__tests__/messaging.test.ts
+++ b/apps/backend/src/services/__tests__/messaging.test.ts
@@ -249,6 +249,8 @@ describe("messaging service", () => {
 
   it("sends a message for participants and trims content", async () => {
     enqueueResponse({ table: "conversation_participants", operation: "select", data: [{ id: "p1" }] });
+    // Sold-listing guard: fetch conversation listing_id (null = no linked listing, guard passes).
+    enqueueResponse({ table: "conversations", operation: "select", data: { id: "c1", listing_id: null } });
     enqueueResponse({
       table: "messages",
       operation: "insert",

--- a/apps/backend/src/services/listings.ts
+++ b/apps/backend/src/services/listings.ts
@@ -408,6 +408,121 @@ export async function unpublishListing(id: string, userId: string): Promise<List
   return updateListing(id, userId, { status: "draft" });
 }
 
+/** Error thrown when attempting to mark a listing as sold that is already sold. */
+export class ListingAlreadySoldError extends Error {
+  readonly code = "LISTING_ALREADY_SOLD";
+
+  constructor() {
+    super("This listing is already marked as sold");
+    this.name = "ListingAlreadySoldError";
+  }
+}
+
+/**
+ * Marks a listing as sold.
+ *
+ * Removes it from public search, keeps it visible to the seller,
+ * and sends a listing_sold notification to all users who wishlisted it
+ * or have an open conversation about it (excluding the seller).
+ *
+ * param listingId - UUID of the listing to mark as sold.
+ * param userId - UUID of the seller (must own the listing).
+ * returns The updated Listing record with status "sold".
+ * throws Error if the listing does not exist or you do not have permission to modify it.
+ * throws ListingAlreadySoldError if already sold.
+ */
+export async function markListingAsSold(listingId: string, userId: string): Promise<Listing> {
+  if (!listingId.trim()) throw new Error("Listing ID is required");
+  if (!userId.trim()) throw new Error("User ID is required");
+
+  // Atomically update to "sold" only if we own it and it's not already sold.
+  const { data: updated, error: updateError } = await supabase
+    .from("listings")
+    .update({ status: "sold" })
+    .eq("id", listingId)
+    .eq("user_id", userId)
+    .neq("status", "sold")
+    .is("deleted_at", null)
+    .select(listingSelect)
+    .single<ListingRow>();
+
+  if (updateError || !updated) {
+    // One read on the failure path to give a precise error.
+    const { data: check } = await supabase
+      .from("listings")
+      .select("status,user_id")
+      .eq("id", listingId)
+      .is("deleted_at", null)
+      .maybeSingle();
+
+    if (!check) throw new Error("Listing not found");
+    if (check.user_id !== userId) throw new Error("Listing not found or you do not have permission to modify it");
+    if (check.status === "sold") throw new ListingAlreadySoldError();
+    throw new Error(`Failed to mark listing as sold: ${updateError?.message ?? "no data returned"}`);
+  }
+
+  // 4. Collect user IDs from wishlists (excluding the seller)
+  const { data: wishlistRows } = await supabase
+    .from("wishlists")
+    .select("user_id")
+    .eq("listing_id", listingId)
+    .neq("user_id", userId);
+
+  const wishlistUserIds: string[] = (wishlistRows ?? []).map(
+    (r: { user_id: string }) => r.user_id,
+  );
+
+  // 5. Collect user IDs from conversations linked to this listing (excluding seller)
+  // Two-step: first find conversation IDs for this listing, then find participants.
+  const { data: linkedConvos } = await supabase
+    .from("conversations")
+    .select("id")
+    .eq("listing_id", listingId)
+    .is("deleted_at", null);
+
+  const linkedConvoIds = (linkedConvos ?? []).map((r: { id: string }) => r.id);
+
+  const conversationUserIds: string[] = [];
+  if (linkedConvoIds.length > 0) {
+    const { data: participantRows } = await supabase
+      .from("conversation_participants")
+      .select("user_id")
+      .in("conversation_id", linkedConvoIds)
+      .neq("user_id", userId)
+      .is("left_at", null);
+
+    conversationUserIds.push(
+      ...(participantRows ?? []).map((r: { user_id: string }) => r.user_id),
+    );
+  }
+
+  // 6. Deduplicate (wishlist and conversation lists may overlap).
+  // The seller is excluded at the DB level in both queries, but the filter
+  // here guards the edge case where a seller wishlists their own listing.
+  const notifyUserIds = [
+    ...new Set([...wishlistUserIds, ...conversationUserIds].filter((id) => id !== userId)),
+  ];
+
+  // 7. Batch-insert notifications (skip if no one to notify)
+  if (notifyUserIds.length > 0) {
+    const notifications = notifyUserIds.map((notifyUserId) => ({
+      user_id: notifyUserId,
+      type: "listing_sold",
+      payload: { listing_id: listingId, listing_title: updated.title },
+    }));
+
+    const { error: notifyError } = await supabase.from("notifications").insert(notifications);
+    if (notifyError) {
+      console.warn(
+        `[markListingAsSold] Failed to insert sold notifications for listing ${listingId}:`,
+        notifyError.message,
+      );
+    }
+  }
+
+  return mapListingRow(updated);
+}
+
 /**
  * Soft-deletes a listing by setting `deleted_at`. Only the listing's owner may delete it.
  *

--- a/apps/backend/src/services/messaging.ts
+++ b/apps/backend/src/services/messaging.ts
@@ -2,6 +2,7 @@
 // Coordinates reads/writes across public.conversations, public.conversation_participants, and public.messages.
 
 import { supabase } from "../supabase-client.js";
+import type { ListingStatus } from "./listings.types.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -26,6 +27,8 @@ export interface Conversation {
   is_seller?: boolean;
   // Storage path of the other user's avatar (pass to getAvatarUrl to get a URL).
   other_user_avatar_path?: string | null;
+  // Status of the linked listing ("active", "sold", "draft", etc.). Null if no listing.
+  listing_status?: ListingStatus | null;
 }
 
 export interface Message {
@@ -36,6 +39,16 @@ export interface Message {
   is_read: boolean;
   read_at: string | null;
   created_at: string;
+}
+
+/** Thrown when trying to send a message in a conversation whose linked listing is sold. */
+export class ConversationLockedError extends Error {
+  readonly code = "CONVERSATION_LOCKED";
+
+  constructor() {
+    super("This conversation is locked because the listing has been sold");
+    this.name = "ConversationLockedError";
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -82,11 +95,13 @@ async function isParticipant(conversationId: string, userId: string): Promise<bo
   return (data ?? []).length > 0;
 }
 
-// Fetch listing title and owner for a given listing_id.
-async function getListingInfo(listingId: string): Promise<{ title: string; user_id: string } | null> {
+// Fetch listing title, owner, and status for a given listing_id.
+async function getListingInfo(
+  listingId: string,
+): Promise<{ title: string; user_id: string; status: ListingStatus } | null> {
   const { data } = await supabase
     .from("listings")
-    .select("title,user_id")
+    .select("title,user_id,status")
     .eq("id", listingId)
     .single();
 
@@ -273,6 +288,7 @@ export async function getConversationsByUser(userId: string): Promise<Conversati
       unread_count: count ?? 0,
       listing_title: listingInfo?.title,
       is_seller: listingInfo ? listingInfo.user_id === userId : undefined,
+      listing_status: listingInfo?.status ?? null,
     });
   }
 
@@ -335,6 +351,7 @@ export async function getConversation(conversationId: string, userId: string): P
     unread_count: count ?? 0,
     listing_title: listingInfo?.title,
     is_seller: listingInfo ? listingInfo.user_id === userId : undefined,
+    listing_status: listingInfo?.status ?? null,
   };
 }
 
@@ -377,10 +394,30 @@ export async function sendMessage(conversationId: string, senderId: string, cont
   const trimmedContent = content.trim();
   if (!trimmedContent) throw new Error("Message content cannot be empty");
 
-  // Verify sender is a participant.
+  // Verify sender is a participant before any other checks.
   const senderIsParticipant = await isParticipant(conversationId, senderId);
   if (!senderIsParticipant) {
     throw new Error("You are not a participant in this conversation");
+  }
+
+  // Guard: block messages if the linked listing has been sold.
+  const { data: convoCheck } = await supabase
+    .from("conversations")
+    .select("listing_id")
+    .eq("id", conversationId)
+    .is("deleted_at", null)
+    .single();
+
+  if (convoCheck?.listing_id) {
+    const { data: listingCheck } = await supabase
+      .from("listings")
+      .select("status")
+      .eq("id", convoCheck.listing_id)
+      .single();
+
+    if (listingCheck?.status === "sold") {
+      throw new ConversationLockedError();
+    }
   }
 
   // Insert the message.

--- a/apps/web/src/components/ChatPanel.tsx
+++ b/apps/web/src/components/ChatPanel.tsx
@@ -15,6 +15,7 @@ type ChatPanelProps = {
     listingId?: string | null;
     listingTitle?: string;
     isSeller?: boolean;
+    listingStatus?: string | null;
 };
 
 // Format a timestamp like "3:42 PM".
@@ -37,9 +38,12 @@ export default function ChatPanel({
     listingId,
     listingTitle,
     isSeller,
+    listingStatus,
 }: ChatPanelProps) {
     // Auto-scroll to the bottom when new messages arrive.
     const bottomRef = useRef<HTMLDivElement>(null);
+
+    const isSold = listingStatus === "sold";
 
     useEffect(() => {
         bottomRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -145,20 +149,28 @@ export default function ChatPanel({
                 <div ref={bottomRef} />
             </div>
 
+            {/* Sold banner — shown when the linked listing has been sold */}
+            {isSold && (
+                <div className="mx-2 mb-0 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-3 text-center text-sm text-[var(--color-text-muted)]">
+                    This item has been sold. Messaging is no longer available.
+                </div>
+            )}
+
             {/* Message input */}
             <div className="m-2 mt-0 flex items-center gap-2 border-t border-[var(--color-border)] bg-[var(--color-background)] p-3">
                 <input
                     type="text"
-                    placeholder="Type a message..."
+                    placeholder={isSold ? "This conversation is closed" : "Type a message..."}
                     value={messageInput}
                     onChange={(e) => onInputChange(e.target.value)}
                     onKeyDown={handleKeyDown}
-                    className="flex-1 rounded-lg border border-[var(--color-border)] bg-transparent px-4 py-2.5 text-sm outline-none focus:ring-2 focus:ring-[var(--color-primary)]/30 transition-all placeholder:text-[var(--color-text-muted)]"
+                    disabled={isSold}
+                    className="flex-1 rounded-lg border border-[var(--color-border)] bg-transparent px-4 py-2.5 text-sm outline-none focus:ring-2 focus:ring-[var(--color-primary)]/30 transition-all placeholder:text-[var(--color-text-muted)] disabled:opacity-50 disabled:cursor-not-allowed"
                 />
                 <button
                     type="button"
                     onClick={onSend}
-                    disabled={!messageInput.trim()}
+                    disabled={!messageInput.trim() || isSold}
                     className="flex items-center gap-2 rounded-lg bg-[var(--color-primary)] px-5 py-2.5 text-sm font-semibold text-[var(--color-text-on-primary)] disabled:opacity-40 hover:opacity-90 transition-opacity"
                 >
                     <Send size={16} />

--- a/apps/web/src/pages/messages.tsx
+++ b/apps/web/src/pages/messages.tsx
@@ -287,6 +287,7 @@ export default function Messages() {
                             listingId={activeConvo.listing_id}
                             listingTitle={activeConvo.listing_title}
                             isSeller={activeConvo.is_seller}
+                            listingStatus={activeConvo.listing_status}
                         />
                     ) : (
                         <div className="flex h-full w-full flex-col border-l border-[var(--color-border)]">

--- a/docs/superpowers/plans/2026-04-16-mark-listing-sold.md
+++ b/docs/superpowers/plans/2026-04-16-mark-listing-sold.md
@@ -1,0 +1,591 @@
+# Mark Listing as Sold — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `markListingAsSold` to the backend, guard `sendMessage` against sold listings, and show a sold banner in `ChatPanel`.
+
+**Architecture:** `markListingAsSold` in `listings.ts` updates the listing status, then batch-notifies all wishlisted users and conversation participants (deduped). `sendMessage` in `messaging.ts` gains a guard that throws `ConversationLockedError` when the linked listing is sold. `Conversation` gets a `listing_status` field so `ChatPanel` can disable input without an extra fetch.
+
+**Tech Stack:** TypeScript, Supabase JS client, Vitest (integration tests against real Supabase), React + Tailwind CSS
+
+---
+
+### Task 1: Add `ListingAlreadySoldError` and `markListingAsSold` to `listings.ts`
+
+**Files:**
+- Modify: `apps/backend/src/services/listings.ts` (after `unpublishListing` at line 408)
+
+- [ ] **Step 1: Add the error class and function skeleton after `unpublishListing`**
+
+Open `apps/backend/src/services/listings.ts`. After the `unpublishListing` function (line ~408), insert:
+
+```typescript
+/** Error thrown when attempting to mark a listing as sold that is already sold. */
+export class ListingAlreadySoldError extends Error {
+  readonly code = "LISTING_ALREADY_SOLD";
+
+  constructor() {
+    super("This listing is already marked as sold");
+    this.name = "ListingAlreadySoldError";
+  }
+}
+
+/**
+ * Marks a listing as sold.
+ *
+ * Removes it from public search, keeps it visible to the seller,
+ * and sends a listing_sold notification to all users who wishlisted it
+ * or have an open conversation about it (excluding the seller).
+ *
+ * param listingId - UUID of the listing to mark as sold.
+ * param userId - UUID of the seller (must own the listing).
+ * returns The updated Listing record with status "sold".
+ * throws ListingNotFoundError if the listing does not exist.
+ * throws ListingPermissionError if the caller is not the owner.
+ * throws ListingAlreadySoldError if already sold.
+ */
+export async function markListingAsSold(listingId: string, userId: string): Promise<Listing> {
+  // 1. Verify ownership (throws if missing or wrong user)
+  await verifyListingOwnership(listingId, userId);
+
+  // 2. Fetch current status to guard against double-selling
+  const listing = await getListingById(listingId);
+  if (listing.status === "sold") {
+    throw new ListingAlreadySoldError();
+  }
+
+  // 3. Update status to sold
+  const { data: updated, error: updateError } = await supabase
+    .from("listings")
+    .update({ status: "sold" })
+    .eq("id", listingId)
+    .select(listingSelect)
+    .single<ListingRow>();
+
+  if (updateError || !updated) {
+    throw new Error(`Failed to mark listing as sold: ${updateError?.message ?? "no data returned"}`);
+  }
+
+  // 4. Collect user IDs from wishlists
+  const { data: wishlistRows } = await supabase
+    .from("wishlists")
+    .select("user_id")
+    .eq("listing_id", listingId);
+
+  const wishlistUserIds: string[] = (wishlistRows ?? []).map(
+    (r: { user_id: string }) => r.user_id,
+  );
+
+  // 5. Collect user IDs from conversations linked to this listing (excluding seller)
+  // Two-step: first find conversation IDs for this listing, then find participants.
+  const { data: linkedConvos } = await supabase
+    .from("conversations")
+    .select("id")
+    .eq("listing_id", listingId)
+    .is("deleted_at", null);
+
+  const linkedConvoIds = (linkedConvos ?? []).map((r: { id: string }) => r.id);
+
+  const conversationUserIds: string[] = [];
+  if (linkedConvoIds.length > 0) {
+    const { data: participantRows } = await supabase
+      .from("conversation_participants")
+      .select("user_id")
+      .in("conversation_id", linkedConvoIds)
+      .neq("user_id", userId)
+      .is("left_at", null);
+
+    conversationUserIds.push(
+      ...(participantRows ?? []).map((r: { user_id: string }) => r.user_id),
+    );
+  }
+
+  // 6. Deduplicate and exclude the seller
+  const notifyUserIds = [
+    ...new Set([...wishlistUserIds, ...conversationUserIds].filter((id) => id !== userId)),
+  ];
+
+  // 7. Batch-insert notifications (skip if no one to notify)
+  if (notifyUserIds.length > 0) {
+    const notifications = notifyUserIds.map((notifyUserId) => ({
+      user_id: notifyUserId,
+      type: "listing_sold",
+      payload: { listing_id: listingId, listing_title: listing.title },
+    }));
+
+    await supabase.from("notifications").insert(notifications);
+  }
+
+  return mapListingRow(updated);
+}
+```
+
+- [ ] **Step 2: Run typecheck**
+
+```bash
+npm run typecheck --workspace=apps/backend
+```
+
+Expected: no errors
+
+---
+
+### Task 2: Write integration tests for `markListingAsSold`
+
+**Files:**
+- Modify: `apps/backend/src/services/__tests__/listings.test.ts`
+
+- [ ] **Step 1: Add imports at the top of the test file**
+
+In the import block at the top of `listings.test.ts`, add `markListingAsSold` and `ListingAlreadySoldError` to the existing import:
+
+```typescript
+import {
+  // ...existing imports...
+  markListingAsSold,
+  ListingAlreadySoldError,
+} from "../listings.js";
+```
+
+Also add a second test user variable near the top of the file (alongside `let testUser`):
+
+```typescript
+let secondUser: TestUser;
+```
+
+And in `beforeAll`, create it:
+
+```typescript
+secondUser = await createTestUser("Second Test User");
+```
+
+And in `afterAll`, clean it up:
+
+```typescript
+await secondUser.cleanup();
+```
+
+- [ ] **Step 2: Add the test suite**
+
+Append at the bottom of `listings.test.ts`:
+
+```typescript
+describe("markListingAsSold", () => {
+  it("sets status to sold and removes listing from public search", async () => {
+    const listing = await createPublishableDraft(testUser.user.id);
+    await publishListing(listing.id, testUser.user.id);
+
+    const sold = await markListingAsSold(listing.id, testUser.user.id);
+
+    expect(sold.status).toBe("sold");
+
+    // Should no longer appear in public search
+    const results = await searchListings({});
+    expect(results.some((l) => l.id === listing.id)).toBe(false);
+
+    // Seller can still see it
+    const sellerListings = await getListingsByUser(testUser.user.id);
+    expect(sellerListings.some((l) => l.id === listing.id)).toBe(true);
+  });
+
+  it("throws ListingAlreadySoldError if already sold", async () => {
+    const listing = await createTestListing(testUser.user.id, {
+      title: "Already Sold Listing",
+    });
+    trackListing(listing.id);
+    await supabase.from("listings").update({ status: "sold" }).eq("id", listing.id);
+
+    await expect(markListingAsSold(listing.id, testUser.user.id)).rejects.toBeInstanceOf(
+      ListingAlreadySoldError,
+    );
+  });
+
+  it("throws when called by a non-owner", async () => {
+    const listing = await createTestListing(testUser.user.id, {
+      title: "Other Owner Listing",
+    });
+    trackListing(listing.id);
+
+    await expect(markListingAsSold(listing.id, secondUser.user.id)).rejects.toThrow();
+  });
+
+  it("creates listing_sold notifications for wishlisted users", async () => {
+    const listing = await createPublishableDraft(testUser.user.id, {
+      title: "Wishlisted Item",
+    });
+
+    // Add secondUser to wishlist directly via supabase (bypasses RLS using service key)
+    await supabase.from("wishlists").insert({
+      user_id: secondUser.user.id,
+      listing_id: listing.id,
+    });
+
+    await markListingAsSold(listing.id, testUser.user.id);
+
+    const { data: notifications } = await supabase
+      .from("notifications")
+      .select("*")
+      .eq("user_id", secondUser.user.id)
+      .eq("type", "listing_sold")
+      .eq("payload->listing_id", listing.id);
+
+    expect(notifications?.length).toBeGreaterThanOrEqual(1);
+    expect(notifications![0].payload.listing_title).toBe("Wishlisted Item");
+
+    // Cleanup
+    await supabase.from("wishlists").delete().eq("listing_id", listing.id);
+    await supabase.from("notifications").delete().eq("payload->listing_id", listing.id);
+  });
+
+  it("does not create a notification for the seller", async () => {
+    const listing = await createPublishableDraft(testUser.user.id, {
+      title: "Seller No Notify",
+    });
+
+    // Seller wishlists their own listing (edge case)
+    await supabase.from("wishlists").insert({
+      user_id: testUser.user.id,
+      listing_id: listing.id,
+    });
+
+    await markListingAsSold(listing.id, testUser.user.id);
+
+    const { data: notifications } = await supabase
+      .from("notifications")
+      .select("*")
+      .eq("user_id", testUser.user.id)
+      .eq("type", "listing_sold")
+      .eq("payload->listing_id", listing.id);
+
+    expect(notifications?.length ?? 0).toBe(0);
+
+    // Cleanup
+    await supabase.from("wishlists").delete().eq("listing_id", listing.id);
+  });
+});
+```
+
+- [ ] **Step 3: Run the new tests**
+
+```bash
+npm run test --workspace=apps/backend -- --reporter=verbose 2>&1 | grep -A 5 "markListingAsSold"
+```
+
+Expected: all `markListingAsSold` tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/backend/src/services/listings.ts apps/backend/src/services/__tests__/listings.test.ts
+git commit -m "feat: add markListingAsSold with wishlist/conversation notifications"
+```
+
+---
+
+### Task 3: Add `listing_status` to `Conversation` and update queries in `messaging.ts`
+
+**Files:**
+- Modify: `apps/backend/src/services/messaging.ts`
+
+- [ ] **Step 1: Add `ListingStatus` import**
+
+At the top of `messaging.ts`, add the import:
+
+```typescript
+import type { ListingStatus } from "./listings.types.js";
+```
+
+- [ ] **Step 2: Add `listing_status` to the `Conversation` interface**
+
+In the `Conversation` interface (lines 10–29), add the new field after `is_seller`:
+
+```typescript
+  // Status of the linked listing ("active", "sold", "draft", etc.). Null if no listing.
+  listing_status?: ListingStatus | null;
+```
+
+- [ ] **Step 3: Update `getListingInfo` helper to return status**
+
+Replace the existing `getListingInfo` helper (around line 86):
+
+```typescript
+async function getListingInfo(
+  listingId: string,
+): Promise<{ title: string; user_id: string; status: ListingStatus } | null> {
+  const { data } = await supabase
+    .from("listings")
+    .select("title,user_id,status")
+    .eq("id", listingId)
+    .single();
+
+  return data ?? null;
+}
+```
+
+- [ ] **Step 4: Update `getConversationsByUser` to include `listing_status`**
+
+In the `results.push({...})` block inside `getConversationsByUser` (around line 264), add `listing_status` after `is_seller`:
+
+```typescript
+      listing_title: listingInfo?.title,
+      is_seller: listingInfo ? listingInfo.user_id === userId : undefined,
+      listing_status: listingInfo?.status ?? null,
+```
+
+- [ ] **Step 5: Update `getConversation` to include `listing_status`**
+
+In the `return {...}` block of `getConversation` (around line 326), add `listing_status` after `is_seller`:
+
+```typescript
+    listing_title: listingInfo?.title,
+    is_seller: listingInfo ? listingInfo.user_id === userId : undefined,
+    listing_status: listingInfo?.status ?? null,
+```
+
+- [ ] **Step 6: Run typecheck**
+
+```bash
+npm run typecheck --workspace=apps/backend
+```
+
+Expected: no errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/backend/src/services/messaging.ts
+git commit -m "feat: expose listing_status on Conversation for sold-state UI"
+```
+
+---
+
+### Task 4: Add `ConversationLockedError` and guard in `sendMessage`
+
+**Files:**
+- Modify: `apps/backend/src/services/messaging.ts`
+
+- [ ] **Step 1: Add the error class**
+
+Near the top of `messaging.ts`, after the type definitions (after the `Message` interface, around line 39), add:
+
+```typescript
+/** Thrown when trying to send a message in a conversation whose linked listing is sold. */
+export class ConversationLockedError extends Error {
+  readonly code = "CONVERSATION_LOCKED";
+
+  constructor() {
+    super("This conversation is locked because the listing has been sold");
+    this.name = "ConversationLockedError";
+  }
+}
+```
+
+- [ ] **Step 2: Add the guard at the top of `sendMessage`**
+
+In `sendMessage` (around line 373), after the three input validation checks and before the `isParticipant` check, insert:
+
+```typescript
+  // Guard: block messages if the linked listing has been sold.
+  const { data: convoCheck } = await supabase
+    .from("conversations")
+    .select("listing_id")
+    .eq("id", conversationId)
+    .is("deleted_at", null)
+    .single();
+
+  if (convoCheck?.listing_id) {
+    const { data: listingCheck } = await supabase
+      .from("listings")
+      .select("status")
+      .eq("id", convoCheck.listing_id)
+      .single();
+
+    if (listingCheck?.status === "sold") {
+      throw new ConversationLockedError();
+    }
+  }
+```
+
+- [ ] **Step 3: Run typecheck**
+
+```bash
+npm run typecheck --workspace=apps/backend
+```
+
+Expected: no errors
+
+---
+
+### Task 5: Write integration test for the `sendMessage` guard
+
+**Files:**
+- Modify: `apps/backend/src/services/__tests__/listings.test.ts`
+
+We test the guard in the listings test file because it requires a real listing to be marked sold — it fits naturally with the `markListingAsSold` suite.
+
+- [ ] **Step 1: Add the import for messaging functions**
+
+At the top of `listings.test.ts`, add:
+
+```typescript
+import { createConversation, sendMessage, ConversationLockedError } from "../messaging.js";
+```
+
+- [ ] **Step 2: Add the test inside the `markListingAsSold` describe block**
+
+Append inside the `describe("markListingAsSold", ...)` block:
+
+```typescript
+  it("blocks sendMessage after listing is marked sold", async () => {
+    const listing = await createPublishableDraft(testUser.user.id, {
+      title: "Soon To Be Sold",
+    });
+
+    // Create a conversation between testUser (seller) and secondUser (buyer)
+    const conversation = await createConversation(
+      secondUser.user.id,
+      testUser.user.id,
+      listing.id,
+    );
+
+    // Mark it sold
+    await markListingAsSold(listing.id, testUser.user.id);
+
+    // Buyer tries to send a message — should be blocked
+    await expect(
+      sendMessage(conversation.id, secondUser.user.id, "Is this still available?"),
+    ).rejects.toBeInstanceOf(ConversationLockedError);
+  });
+```
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+npm run test --workspace=apps/backend
+```
+
+Expected: all tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/backend/src/services/messaging.ts apps/backend/src/services/__tests__/listings.test.ts
+git commit -m "feat: block sendMessage on sold listings with ConversationLockedError"
+```
+
+---
+
+### Task 6: Update `ChatPanel` with sold banner and disabled input
+
+**Files:**
+- Modify: `apps/web/src/components/ChatPanel.tsx`
+
+- [ ] **Step 1: Add `listingStatus` to `ChatPanelProps`**
+
+In the `ChatPanelProps` type (lines 6–18), add after `isSeller`:
+
+```typescript
+  listingStatus?: string | null;
+```
+
+- [ ] **Step 2: Destructure `listingStatus` in the component**
+
+In the function signature destructure (lines 28–40), add after `isSeller`:
+
+```typescript
+    listingStatus,
+```
+
+- [ ] **Step 3: Derive `isSold` at the top of the component body**
+
+After the `bottomRef` declaration, add:
+
+```typescript
+    const isSold = listingStatus === "sold";
+```
+
+- [ ] **Step 4: Add the sold banner above the message input**
+
+Replace the message input section (the `<div className="m-2 mt-0 ...">` block at lines 149–167) with:
+
+```tsx
+            {/* Sold banner — shown when the linked listing has been sold */}
+            {isSold && (
+                <div className="mx-2 mb-0 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-3 text-center text-sm text-[var(--color-text-muted)]">
+                    This item has been sold. Messaging is no longer available.
+                </div>
+            )}
+
+            {/* Message input */}
+            <div className="m-2 mt-0 flex items-center gap-2 border-t border-[var(--color-border)] bg-[var(--color-background)] p-3">
+                <input
+                    type="text"
+                    placeholder={isSold ? "This conversation is closed" : "Type a message..."}
+                    value={messageInput}
+                    onChange={(e) => onInputChange(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                    disabled={isSold}
+                    className="flex-1 rounded-lg border border-[var(--color-border)] bg-transparent px-4 py-2.5 text-sm outline-none focus:ring-2 focus:ring-[var(--color-primary)]/30 transition-all placeholder:text-[var(--color-text-muted)] disabled:opacity-50 disabled:cursor-not-allowed"
+                />
+                <button
+                    type="button"
+                    onClick={onSend}
+                    disabled={!messageInput.trim() || isSold}
+                    className="flex items-center gap-2 rounded-lg bg-[var(--color-primary)] px-5 py-2.5 text-sm font-semibold text-[var(--color-text-on-primary)] disabled:opacity-40 hover:opacity-90 transition-opacity"
+                >
+                    <Send size={16} />
+                    Send
+                </button>
+            </div>
+```
+
+- [ ] **Step 5: Pass `listingStatus` from the messages page**
+
+Open `apps/web/src/pages/messages.tsx`. The `<ChatPanel` render starts at line 278. Add `listingStatus` after `isSeller`:
+
+```tsx
+                        <ChatPanel
+                            messages={messages}
+                            userId={user.id}
+                            otherUserName={activeConvo.other_user_display_name ?? "Unknown User"}
+                            messageInput={messageInput}
+                            onInputChange={setMessageInput}
+                            onSend={handleSend}
+                            loading={chatLoading}
+                            onBack={() => setMobileView("list")}
+                            listingId={activeConvo.listing_id}
+                            listingTitle={activeConvo.listing_title}
+                            isSeller={activeConvo.is_seller}
+                            listingStatus={activeConvo.listing_status}
+                        />
+```
+
+- [ ] **Step 6: Run typecheck on the frontend**
+
+```bash
+npm run typecheck --workspace=apps/web
+```
+
+Expected: no errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/components/ChatPanel.tsx apps/web/src/pages/messages.tsx
+git commit -m "feat: show sold banner and disable input in ChatPanel for sold listings"
+```
+
+---
+
+## Verification Checklist
+
+- [ ] `markListingAsSold(listingId, sellerId)` → listing status is `"sold"`
+- [ ] `searchListings({})` → sold listing does not appear
+- [ ] `getListingsByUser(sellerId)` → sold listing still visible
+- [ ] `notifications` table has rows for wishlisted users + conversation participants, with `type = "listing_sold"` and correct `listing_title` in payload
+- [ ] Seller has no notification row for their own listing
+- [ ] `sendMessage(conversationId, buyerId, "...")` on a sold-linked conversation → throws `ConversationLockedError`
+- [ ] Messages page: open a conversation for a sold listing → sold banner visible, input disabled
+- [ ] Messages page: open a conversation for an active listing → input works normally
+- [ ] All backend tests pass: `npm run test --workspace=apps/backend`
+- [ ] No type errors: `npm run typecheck`

--- a/docs/superpowers/specs/2026-04-16-mark-listing-sold-design.md
+++ b/docs/superpowers/specs/2026-04-16-mark-listing-sold-design.md
@@ -1,0 +1,140 @@
+# Mark Listing as Sold — Design Spec
+
+**Date:** 2026-04-16  
+**Status:** Approved
+
+## Context
+
+Sellers need a way to mark a listing as sold once a transaction completes. When this happens:
+- The listing disappears from public search (home page)
+- The seller can still see it in their own dashboard
+- Users who wishlisted the item get a notification
+- Users with an open conversation about the listing get a notification and can no longer send new messages
+
+The frontend team owns the "Mark as Sold" button on the listing page. This spec covers only the backend function, the messaging guard, and the ChatPanel sold state in the messages UI.
+
+---
+
+## Scope
+
+| Area | In Scope | Out of Scope |
+|------|----------|--------------|
+| `listings.ts` — `markListingAsSold` | ✅ | |
+| `messaging.ts` — `sendMessage` guard | ✅ | |
+| `ChatPanel.tsx` — sold banner + disabled input | ✅ | |
+| Listing detail page / my-listings page | | ❌ (frontend team) |
+| Notification bell component | | ❌ (no changes needed) |
+
+---
+
+## Backend: `markListingAsSold`
+
+**File:** `apps/backend/src/services/listings.ts`
+
+```typescript
+export async function markListingAsSold(
+  listingId: string,
+  userId: string
+): Promise<Listing>
+```
+
+**Steps:**
+1. Fetch listing by `listingId` — throw `ListingNotFoundError` if missing
+2. Verify `listing.user_id === userId` — throw `ListingPermissionError` if not owner
+3. Throw `ListingAlreadySoldError` if `listing.status === "sold"`
+4. Update `listings.status = "sold"` in Supabase
+5. Query `wishlists` table: `SELECT user_id WHERE listing_id = listingId`
+6. Query `conversation_participants` joined with `conversations`: get all `user_id`s for conversations where `conversations.listing_id = listingId`, excluding the seller (`user_id !== userId`)
+7. Merge both arrays, deduplicate with a `Set`
+8. Batch-insert into `notifications`: `type = "listing_sold"`, `payload = { listing_id: listingId, listing_title: listing.title }`
+9. Return the updated listing
+
+**New error class:**
+```typescript
+export class ListingAlreadySoldError extends Error {}
+```
+
+**No migration needed** — `notifications` table already has `type TEXT, payload JSONB`; `wishlists` and `conversations.listing_id` already exist.
+
+**Auto-export:** `markListingAsSold` and `ListingAlreadySoldError` are picked up by the existing `export * from "./services/listings.js"` in `index.ts`.
+
+---
+
+## Backend: `sendMessage` guard
+
+**File:** `apps/backend/src/services/messaging.ts`
+
+At the top of the existing `sendMessage` function, before inserting the message:
+
+1. Fetch the conversation to get `listing_id`
+2. If `listing_id` is set, fetch `listings.status` for that listing
+3. If status is `"sold"`, throw `ConversationLockedError`
+
+**New error class:**
+```typescript
+export class ConversationLockedError extends Error {}
+```
+
+**Auto-export:** picked up by existing `export * from "./services/messaging.js"` in `index.ts`.
+
+---
+
+## Backend: Expose `listing_status` on `Conversation`
+
+**File:** `apps/backend/src/services/messaging.ts`
+
+The `Conversation` interface currently includes `listing_title` and `is_seller` but not listing status. Add `listing_status` so the frontend can read it without an extra fetch:
+
+```typescript
+// In the Conversation interface:
+listing_status: ListingStatus | null;
+```
+
+Update the SQL in `getConversationsByUser` and `getConversation` to join `listings.status` alongside `listings.title`. If `listing_id` is null, `listing_status` is `null`.
+
+---
+
+## Frontend: ChatPanel sold state
+
+**File:** `apps/web/src/components/ChatPanel.tsx`
+
+The component already receives listing context (title, seller/buyer role). Add:
+
+- If `conversation.listing_status === "sold"`, render a banner above the message input: *"This item has been sold"*
+- Disable the message `<textarea>` and send button when banner is shown
+- `listing_status` comes from the updated `Conversation` object — no new API call needed
+
+---
+
+## Notification Payload
+
+```json
+{
+  "listing_id": "<uuid>",
+  "listing_title": "Used MacBook Pro 14\""
+}
+```
+
+The existing `notification-bell.tsx` already renders payload previews — `listing_title` will surface naturally as the notification description.
+
+---
+
+## Error Handling Summary
+
+| Scenario | Error |
+|----------|-------|
+| Listing not found | `ListingNotFoundError` (existing) |
+| Caller is not the seller | `ListingPermissionError` (existing) |
+| Listing already sold | `ListingAlreadySoldError` (new) |
+| Sending message on sold listing | `ConversationLockedError` (new) |
+
+---
+
+## Verification
+
+1. Call `markListingAsSold(listingId, sellerId)` — verify listing status becomes `"sold"`
+2. Call `searchListings()` — verify the sold listing no longer appears
+3. Call `getListingsByUser(sellerId)` — verify the sold listing is still returned
+4. Check `notifications` table — verify rows exist for all wishlisted users and conversation participants (excluding seller), with correct `type` and `payload`
+5. Call `sendMessage` on a conversation linked to the sold listing — verify `ConversationLockedError` is thrown
+6. Open the messages page as a buyer — verify the sold banner appears and the input is disabled


### PR DESCRIPTION
## Mark Listing as Sold

Adds backend support for marking a listing as sold, notifying affected users,
locking sold-listing conversations, and surfacing the sold state in the messages UI.

---

## Files Changed

### `apps/backend/src/services/listings.ts`

**Added `ListingAlreadySoldError`**

New exported error class thrown when `markListingAsSold` is called on a listing
that is already sold.

```ts
export class ListingAlreadySoldError extends Error {
  readonly code = "LISTING_ALREADY_SOLD";
}
```

**Added `markListingAsSold(listingId, userId)`**

New exported async function. Call it when the seller confirms a sale.

```ts
const updatedListing = await markListingAsSold(listingId, currentUserId);
```

What it does internally:
- Atomically updates `listings.status = "sold"` (single DB call — guards ownership
  and double-sell in one query, no race condition)
- Throws `ListingAlreadySoldError` if already sold
- Throws a permission error if `userId` doesn't own the listing
- Queries `wishlists` for all users who saved this listing
- Queries `conversations` + `conversation_participants` for all users with open
  conversations about this listing
- Deduplicates both lists, excludes the seller
- Batch-inserts `listing_sold` notifications for all affected users

Sold listings are automatically hidden from public search — `searchListings()`
already filters to `status = "active"` only. The seller can still see the listing
via `getListingsByUser(userId)`.

---

### `apps/backend/src/services/messaging.ts`

**Added `ConversationLockedError`**

New exported error class thrown when `sendMessage` is called on a conversation
whose linked listing has been sold.

```ts
export class ConversationLockedError extends Error {
  readonly code = "CONVERSATION_LOCKED";
}
```

**Updated `sendMessage` — sold-listing guard**

Before inserting a message, `sendMessage` now checks if the conversation's linked
listing is sold. If so, it throws `ConversationLockedError`. The participant check
still runs first (non-participants get the participant error, not the lock error).

Frontend error handling example:
```ts
try {
  await sendMessage(conversationId, userId, content);
} catch (err) {
  if (err instanceof ConversationLockedError) {
    // Show "This item has been sold" UI — disable input
  }
}
```

**Updated `Conversation` interface — new `listing_status` field**

```ts
interface Conversation {
  // ...existing fields...
  listing_status?: ListingStatus | null;
}
```

`getConversationsByUser` and `getConversation` now return `listing_status` alongside
`listing_title` and `is_seller`. No extra fetch needed — the status is included in
the same query.

---

### `apps/web/src/components/ChatPanel.tsx`

**New `listingStatus` prop**

```tsx
<ChatPanel
  // ...existing props...
  listingStatus={activeConvo.listing_status}
/>
```

When `listingStatus === "sold"`:
- A banner is shown above the input: *"This item has been sold. Messaging is no
  longer available."*
- The text input is disabled with placeholder "This conversation is closed"
- The send button is disabled

No other behavior changes for active listings.

---

### `apps/web/src/pages/messages.tsx`

Passes `listingStatus={activeConvo.listing_status}` to `<ChatPanel>`. No other
changes — the sold state flows through automatically once the backend returns it.

---

### `apps/backend/src/services/__tests__/listings.test.ts`

Added 6 integration tests (real Supabase, no mocks):

| Test | What it verifies |
|------|-----------------|
| Sets status to sold | `listing.status === "sold"` after call |
| Removed from public search | Not in `searchListings({})` results |
| Seller can still see it | Still in `getListingsByUser(sellerId)` |
| Wishlist notifications | `listing_sold` notification row created for wishlisted user |
| Seller not notified | No notification created for the seller themselves |
| `sendMessage` blocked | `ConversationLockedError` thrown after listing is sold |

---

### `apps/backend/src/services/__tests__/messaging.test.ts`

Updated the mock queue in the `"sends a message for participants"` unit test to
include the new `conversations.select` query the sold-listing guard performs. No
behavior changes — just mock ordering updated to match the new query sequence.

---

## How the Frontend Team Should Use This

### 1. Mark a listing as sold

Import and call from the listing detail page or seller dashboard (wherever the
"Mark as Sold" button lives):

```ts
import { markListingAsSold, ListingAlreadySoldError } from "@campus-marketplace/backend";

async function handleMarkAsSold(listingId: string, userId: string) {
  try {
    const listing = await markListingAsSold(listingId, userId);
    // listing.status === "sold"
    // Redirect or update UI — listing is now hidden from public search
  } catch (err) {
    if (err instanceof ListingAlreadySoldError) {
      // Already sold — update UI accordingly
    } else {
      throw err;
    }
  }
}
```

### 2. Sold state in conversations

No extra work needed. `getConversationsByUser` and `getConversation` already return
`listing_status` on the `Conversation` object. Pass it to `<ChatPanel>`:

```tsx
<ChatPanel
  listingStatus={activeConvo.listing_status}
  // ...
/>
```

ChatPanel handles the banner and disabled input automatically.

### 3. Handle `ConversationLockedError` in send flows

If you have custom send logic outside of `ChatPanel`, catch `ConversationLockedError`
from `sendMessage` and show an appropriate message to the user.

### 4. Notifications

Users who wishlisted the sold listing or had an open conversation about it will
automatically receive a `listing_sold` notification. The notification payload is:

```json
{
  "listing_id": "<uuid>",
  "listing_title": "Used MacBook Pro 14\""
}
```

The existing notification bell renders this automatically — no changes needed.
