### PR TITLE
unit tests for messaging, categories, theme, index

### DIFF
--- a/apps/backend/src/__tests__/index.unit.test.ts
+++ b/apps/backend/src/__tests__/index.unit.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import * as backend from "../index.js";
+
+describe("backend index exports", () => {
+  it("re-exports core service functions", () => {
+    expect(typeof backend.getThemeBySchoolCode).toBe("function");
+    expect(typeof backend.getListingById).toBe("function");
+    expect(typeof backend.getProfile).toBe("function");
+    expect(typeof backend.createConversation).toBe("function");
+    expect(typeof backend.signUpWithEmail).toBe("function");
+    expect(typeof backend.getWishlist).toBe("function");
+    expect(typeof backend.getNotifications).toBe("function");
+    expect(typeof backend.createReport).toBe("function");
+    expect(typeof backend.getCategories).toBe("function");
+    expect(typeof backend.blockUser).toBe("function");
+  });
+});

--- a/apps/backend/src/services/__tests__/categories.unit.test.ts
+++ b/apps/backend/src/services/__tests__/categories.unit.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type QueryOperation = "select";
+
+type QueryResponse = {
+  table: string;
+  operation: QueryOperation;
+  data?: unknown;
+  error?: { message: string } | null;
+};
+
+const { state, supabaseMock } = vi.hoisted(() => {
+  const mockState = {
+    responses: [] as QueryResponse[],
+  };
+
+  function nextResponse(table: string, operation: QueryOperation) {
+    const response = mockState.responses.shift();
+
+    if (!response) {
+      throw new Error(`Unexpected query for ${table}.${operation}`);
+    }
+
+    if (response.table !== table || response.operation !== operation) {
+      throw new Error(
+        `Unexpected query order. Expected ${response.table}.${response.operation} but got ${table}.${operation}`,
+      );
+    }
+
+    return {
+      data: response.data ?? null,
+      error: response.error ?? null,
+    };
+  }
+
+  function createChain(table: string) {
+    const chain: Record<string, unknown> = {};
+
+    chain.select = () => chain;
+    chain.eq = () => chain;
+    chain.is = () => chain;
+    chain.order = () => chain;
+
+    chain.single = async () => nextResponse(table, "select");
+
+    chain.then = (
+      resolve: (value: { data: unknown; error: { message: string } | null }) => unknown,
+      reject?: (reason?: unknown) => unknown,
+    ) => Promise.resolve(nextResponse(table, "select")).then(resolve, reject);
+
+    return chain;
+  }
+
+  return {
+    state: mockState,
+    supabaseMock: {
+      from: (table: string) => createChain(table),
+    },
+  };
+});
+
+function enqueueResponse(response: QueryResponse) {
+  state.responses.push(response);
+}
+
+vi.mock("../../supabase-client.js", () => ({
+  supabase: supabaseMock,
+}));
+
+import { getCategories, getCategoryById, getTags } from "../categories.js";
+
+describe("categories service unit", () => {
+  beforeEach(() => {
+    state.responses.length = 0;
+    vi.restoreAllMocks();
+  });
+
+  it("returns empty arrays for null category/tag lists", async () => {
+    enqueueResponse({ table: "categories", operation: "select", data: null });
+    enqueueResponse({ table: "tags", operation: "select", data: null });
+
+    await expect(getCategories()).resolves.toEqual([]);
+    await expect(getTags()).resolves.toEqual([]);
+  });
+
+  it("surfaces getCategories query errors", async () => {
+    enqueueResponse({ table: "categories", operation: "select", error: { message: "categories failed" } });
+
+    await expect(getCategories()).rejects.toThrow("Failed to fetch categories: categories failed");
+  });
+
+  it("validates and handles getCategoryById failures", async () => {
+    await expect(getCategoryById("")).rejects.toThrow("Category ID is required");
+
+    enqueueResponse({ table: "categories", operation: "select", error: { message: "category failed" } });
+    await expect(getCategoryById("c1")).rejects.toThrow("Failed to fetch category: category failed");
+
+    enqueueResponse({ table: "categories", operation: "select", data: null });
+    await expect(getCategoryById("c1")).rejects.toThrow("Category not found: c1");
+  });
+
+  it("surfaces getTags query errors", async () => {
+    enqueueResponse({ table: "tags", operation: "select", error: { message: "tags failed" } });
+
+    await expect(getTags()).rejects.toThrow("Failed to fetch tags: tags failed");
+  });
+});

--- a/apps/backend/src/services/__tests__/helpers.ts
+++ b/apps/backend/src/services/__tests__/helpers.ts
@@ -22,11 +22,49 @@ export async function createTestUser(displayName = "Test User"): Promise<TestUse
   const email = testEmail();
   const password = "TestPassword123!";
 
-  const result = await signUpWithEmail({
-    email,
-    password,
-    display_name: displayName,
-  });
+  const isRateLimitError = (error: unknown): boolean => {
+    const message = error instanceof Error ? error.message : String(error);
+    return message.toLowerCase().includes("request rate limit reached");
+  };
+
+  let result: AuthResult;
+
+  try {
+    result = await signUpWithEmail({
+      email,
+      password,
+      display_name: displayName,
+    });
+  } catch (error) {
+    if (!isRateLimitError(error)) {
+      throw error;
+    }
+
+    const { data: adminData, error: adminError } = await supabase.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+      user_metadata: { display_name: displayName },
+    });
+
+    if (adminError || !adminData.user) {
+      throw new Error(`Failed to create test user via admin API: ${adminError?.message ?? "unknown error"}`);
+    }
+
+    const { data: sessionData, error: signInError } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+
+    if (signInError) {
+      throw new Error(`Failed to sign in test user via admin fallback: ${signInError.message}`);
+    }
+
+    result = {
+      user: adminData.user,
+      session: sessionData.session ?? null,
+    };
+  }
 
   const cleanup = async () => {
     try {

--- a/apps/backend/src/services/__tests__/messaging.test.ts
+++ b/apps/backend/src/services/__tests__/messaging.test.ts
@@ -14,6 +14,7 @@ const { state, supabaseMock } = vi.hoisted(() => {
   const mockState = {
     responses: [] as QueryResponse[],
     realtimeHandler: null as RealtimeHandler | null,
+    realtimeHandlers: {} as Record<string, RealtimeHandler>,
     removedChannels: [] as string[],
   };
 
@@ -86,6 +87,7 @@ const { state, supabaseMock } = vi.hoisted(() => {
           handler: RealtimeHandler,
         ) => {
           mockState.realtimeHandler = handler;
+          mockState.realtimeHandlers[name] = handler;
           return channel;
         },
         subscribe: () => channel,
@@ -115,17 +117,20 @@ vi.mock("../../supabase-client.js", () => ({
 import {
   archiveConversation,
   createConversation,
+  ConversationLockedError,
   getConversation,
   getConversationsByUser,
   getMessages,
   markMessagesRead,
   sendMessage,
+  subscribeToConversations,
   subscribeToMessages,
 } from "../messaging.js";
 
 afterEach(() => {
   state.responses.length = 0;
   state.realtimeHandler = null;
+  state.realtimeHandlers = {};
   state.removedChannels.length = 0;
   vi.restoreAllMocks();
 });
@@ -191,10 +196,38 @@ describe("messaging service", () => {
     expect(convo.unread_count).toBe(0);
   });
 
+  it("throws when creating a conversation fails during insert or participant add", async () => {
+    vi.spyOn(crypto, "randomUUID").mockReturnValue("00000000-0000-0000-0000-000000000002");
+
+    enqueueResponse({ table: "blocks", operation: "select", data: [] });
+    enqueueResponse({ table: "conversation_participants", operation: "select", data: [] });
+    enqueueResponse({ table: "conversations", operation: "insert", error: { message: "insert convo failed" } });
+
+    await expect(createConversation("u1", "u2")).rejects.toThrow("Failed to create conversation: insert convo failed");
+
+    enqueueResponse({ table: "blocks", operation: "select", data: [] });
+    enqueueResponse({ table: "conversation_participants", operation: "select", data: [] });
+    enqueueResponse({ table: "conversations", operation: "insert", data: null });
+    enqueueResponse({ table: "conversation_participants", operation: "insert", error: { message: "insert participant failed" } });
+
+    await expect(createConversation("u1", "u2")).rejects.toThrow(
+      "Failed to add participants: insert participant failed",
+    );
+  });
+
   it("returns empty list when user has no conversations", async () => {
     enqueueResponse({ table: "conversation_participants", operation: "select", data: [] });
 
     await expect(getConversationsByUser("u1")).resolves.toEqual([]);
+  });
+
+  it("throws when fetching conversations fails", async () => {
+    enqueueResponse({ table: "conversation_participants", operation: "select", error: { message: "participants failed" } });
+    await expect(getConversationsByUser("u1")).rejects.toThrow("Failed to fetch conversations: participants failed");
+
+    enqueueResponse({ table: "conversation_participants", operation: "select", data: [{ conversation_id: "c1" }] });
+    enqueueResponse({ table: "conversations", operation: "select", error: { message: "conversations failed" } });
+    await expect(getConversationsByUser("u1")).rejects.toThrow("Failed to fetch conversations: conversations failed");
   });
 
   it("hydrates conversation list with listing context", async () => {
@@ -223,6 +256,19 @@ describe("messaging service", () => {
     await expect(getConversation("c1", "u1")).rejects.toThrow("Conversation not found");
   });
 
+  it("throws when the other participant cannot be resolved", async () => {
+    enqueueResponse({
+      table: "conversations",
+      operation: "select",
+      data: { id: "c1", listing_id: null, created_at: "2026-01-01", updated_at: "2026-01-02" },
+    });
+    enqueueResponse({ table: "conversation_participants", operation: "select", data: [] });
+
+    await expect(getConversation("c1", "u1")).rejects.toThrow(
+      "Could not find the other participant in this conversation",
+    );
+  });
+
   it("gets messages sorted query path and validates conversation existence", async () => {
     enqueueResponse({ table: "conversations", operation: "select", data: { id: "c1" } });
     enqueueResponse({
@@ -247,9 +293,15 @@ describe("messaging service", () => {
     await expect(getMessages("")).rejects.toThrow("Conversation ID is required");
   });
 
+  it("throws when fetching messages fails", async () => {
+    enqueueResponse({ table: "conversations", operation: "select", data: { id: "c1" } });
+    enqueueResponse({ table: "messages", operation: "select", error: { message: "messages query failed" } });
+
+    await expect(getMessages("c1")).rejects.toThrow("Failed to fetch messages: messages query failed");
+  });
+
   it("sends a message for participants and trims content", async () => {
     enqueueResponse({ table: "conversation_participants", operation: "select", data: [{ id: "p1" }] });
-    // Sold-listing guard: fetch conversation listing_id (null = no linked listing, guard passes).
     enqueueResponse({ table: "conversations", operation: "select", data: { id: "c1", listing_id: null } });
     enqueueResponse({
       table: "messages",
@@ -280,12 +332,36 @@ describe("messaging service", () => {
     );
   });
 
+  it("throws when sending a message fails to insert", async () => {
+    enqueueResponse({ table: "conversation_participants", operation: "select", data: [{ id: "p1" }] });
+    enqueueResponse({ table: "conversations", operation: "select", data: { id: "c1", listing_id: null } });
+    enqueueResponse({ table: "messages", operation: "insert", error: { message: "insert message failed" }, data: null });
+
+    await expect(sendMessage("c1", "u1", "hello")).rejects.toThrow(
+      "Failed to send message: insert message failed",
+    );
+  });
+
+  it("blocks sendMessage when the linked listing is sold", async () => {
+    enqueueResponse({ table: "conversation_participants", operation: "select", data: [{ id: "p1" }] });
+    enqueueResponse({ table: "conversations", operation: "select", data: { id: "c1", listing_id: "listing-1" } });
+    enqueueResponse({ table: "listings", operation: "select", data: { status: "sold" } });
+
+    await expect(sendMessage("c1", "u1", "hello")).rejects.toBeInstanceOf(ConversationLockedError);
+  });
+
   it("marks messages read and validates required input", async () => {
     enqueueResponse({ table: "messages", operation: "update", data: null });
 
     await expect(markMessagesRead("c1", "u1")).resolves.toBeUndefined();
     await expect(markMessagesRead("", "u1")).rejects.toThrow("Conversation ID is required");
     await expect(markMessagesRead("c1", "")).rejects.toThrow("User ID is required");
+  });
+
+  it("throws when marking messages read fails", async () => {
+    enqueueResponse({ table: "messages", operation: "update", error: { message: "update failed" } });
+
+    await expect(markMessagesRead("c1", "u1")).rejects.toThrow("Failed to mark messages read: update failed");
   });
 
   it("subscribes and unsubscribes to realtime messages", async () => {
@@ -295,7 +371,7 @@ describe("messaging service", () => {
       received.push(msg.id);
     });
 
-    state.realtimeHandler?.({
+    state.realtimeHandlers["messages:c1"]?.({
       new: {
         id: "m-sub",
         conversation_id: "c1",
@@ -313,6 +389,10 @@ describe("messaging service", () => {
     expect(state.removedChannels).toContain("messages:c1");
   });
 
+  it("validates subscribeToMessages input", () => {
+    expect(() => subscribeToMessages("", () => undefined)).toThrow("Conversation ID is required");
+  });
+
   it("archives conversation only for participants", async () => {
     enqueueResponse({ table: "conversation_participants", operation: "select", data: [] });
     await expect(archiveConversation("c1", "u1")).rejects.toThrow("Not a participant in this conversation");
@@ -320,5 +400,35 @@ describe("messaging service", () => {
     enqueueResponse({ table: "conversation_participants", operation: "select", data: [{ id: "p1" }] });
     enqueueResponse({ table: "conversations", operation: "update", data: null });
     await expect(archiveConversation("c1", "u1")).resolves.toBeUndefined();
+  });
+
+  it("throws when archiving a conversation fails", async () => {
+    enqueueResponse({ table: "conversation_participants", operation: "select", data: [{ id: "p1" }] });
+    enqueueResponse({ table: "conversations", operation: "update", error: { message: "archive failed" } });
+
+    await expect(archiveConversation("c1", "u1")).rejects.toThrow(
+      "Failed to archive conversation: archive failed",
+    );
+  });
+
+  it("subscribes to conversation updates and filters payload ids", () => {
+    const changed: string[] = [];
+
+    const subscription = subscribeToConversations(["c1", "c2"], () => {
+      changed.push("changed");
+    });
+
+    state.realtimeHandlers["conversations:c1,c2"]?.({ new: { id: "c3" } });
+    state.realtimeHandlers["conversations:c1,c2"]?.({ new: { id: "c2" } });
+
+    subscription.unsubscribe();
+
+    expect(changed).toHaveLength(1);
+    expect(state.removedChannels).toContain("conversations:c1,c2");
+  });
+
+  it("returns no-op unsubscribe for empty subscribeToConversations input", () => {
+    const subscription = subscribeToConversations([], () => undefined);
+    expect(() => subscription.unsubscribe()).not.toThrow();
   });
 });

--- a/apps/backend/src/services/__tests__/theme.unit.test.ts
+++ b/apps/backend/src/services/__tests__/theme.unit.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type QueryResponse = {
+  data?: unknown;
+  error?: { message: string } | null;
+};
+
+const { state, supabaseMock } = vi.hoisted(() => {
+  const mockState = {
+    response: { data: null, error: null } as QueryResponse,
+  };
+
+  const chain = {
+    select: () => chain,
+    eq: () => chain,
+    single: async () => ({
+      data: mockState.response.data ?? null,
+      error: mockState.response.error ?? null,
+    }),
+  };
+
+  return {
+    state: mockState,
+    supabaseMock: {
+      from: () => chain,
+    },
+  };
+});
+
+vi.mock("../../supabase-client.js", () => ({
+  supabase: supabaseMock,
+}));
+
+import { getThemeBySchoolCode } from "../theme.js";
+
+describe("theme service unit", () => {
+  beforeEach(() => {
+    state.response = { data: null, error: null };
+    vi.restoreAllMocks();
+  });
+
+  it("returns theme data for a valid school code", async () => {
+    state.response = {
+      data: {
+        school_code: 123456,
+        school_name: "Test University",
+        primary_color: "#111111",
+        secondary_color: "#222222",
+      },
+      error: null,
+    };
+
+    const theme = await getThemeBySchoolCode(123456);
+
+    expect(theme.school_code).toBe(123456);
+    expect(theme.school_name).toBe("Test University");
+  });
+
+  it("throws with school-code context when query fails", async () => {
+    state.response = {
+      data: null,
+      error: { message: "theme lookup failed" },
+    };
+
+    await expect(getThemeBySchoolCode(999999)).rejects.toThrow(
+      'Failed to fetch theme for school code "999999": theme lookup failed',
+    );
+  });
+});


### PR DESCRIPTION
chore: expand backend unit coverage and stabilize test-user setup

Description
This PR adds the next backend unit-test coverage slice for CM-US-033 and restores the missing messaging coverage onto the latest branch version.

What changed:

Expanded [messaging.test.ts](vscode-file://vscode-app/c:/Users/jedim/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with additional error-path and subscription tests, including sold-listing message locking.
Added [categories.unit.test.ts](vscode-file://vscode-app/c:/Users/jedim/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for categories/tags success and failure paths.
Added [theme.unit.test.ts](vscode-file://vscode-app/c:/Users/jedim/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for theme fetch success and failure paths.
Added [index.unit.test.ts](vscode-file://vscode-app/c:/Users/jedim/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to verify backend service re-exports.
Updated [helpers.ts](vscode-file://vscode-app/c:/Users/jedim/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html) so test-user creation falls back to the admin API when Supabase signup rate limits are hit.
Validation:

npm run test --workspace=apps/backend
npm run test:coverage --workspace=apps/backend
Current coverage after this slice:

Lines/Statements: 88.47%
Branches: 74.91%
Functions: 100%
Notes:

Coverage improved, but the global 90% gate is still not met yet.
The next highest-impact work is still branch-heavy listing/notification paths.