### PR TITLE
Unit tests notifs listings stats

### DIFF
--- a/apps/backend/src/services/__tests__/auth.unit.test.ts
+++ b/apps/backend/src/services/__tests__/auth.unit.test.ts
@@ -86,6 +86,24 @@ describe("auth service unit", () => {
     );
   });
 
+  it("validates signUpWithEmail required fields and password length", async () => {
+    await expect(signUpWithEmail({ email: "", password: "Password123", display_name: "Name" })).rejects.toThrow(
+      "Email is required",
+    );
+    await expect(signUpWithEmail({ email: "a@school.edu", password: "", display_name: "Name" })).rejects.toThrow(
+      "Password is required",
+    );
+    await expect(signUpWithEmail({ email: "a@school.edu", password: "123", display_name: "Name" })).rejects.toThrow(
+      "Password must be at least 6 characters",
+    );
+    await expect(signUpWithEmail({ email: "a@school.edu", password: "Password123", display_name: "" })).rejects.toThrow(
+      "Display name is required",
+    );
+    await expect(signUpWithEmail({ email: "a@gmail.com", password: "Password123", display_name: "Name" })).rejects.toThrow(
+      "Only .edu email addresses are allowed to sign up.",
+    );
+  });
+
   it("signUpWithEmail throws for invalid account_type", async () => {
     await expect(
       signUpWithEmail({
@@ -135,12 +153,22 @@ describe("auth service unit", () => {
     );
   });
 
+  it("validates signInWithEmail required fields", async () => {
+    await expect(signInWithEmail({ email: "", password: "pass123" })).rejects.toThrow("Email is required");
+    await expect(signInWithEmail({ email: "u@school.edu", password: "" })).rejects.toThrow("Password is required");
+  });
+
   it("getSessionFromTokens handles setSession failures", async () => {
     authMock.setSession.mockResolvedValueOnce({ data: { user: null, session: null }, error: { message: "expired" } });
     await expect(getSessionFromTokens("a", "r")).rejects.toThrow("Failed to restore session: expired");
 
     authMock.setSession.mockResolvedValueOnce({ data: { user: null, session: null }, error: null });
     await expect(getSessionFromTokens("a", "r")).rejects.toThrow("Session restore did not return a user");
+  });
+
+  it("validates getSessionFromTokens required fields", async () => {
+    await expect(getSessionFromTokens("", "r")).rejects.toThrow("Access token is required");
+    await expect(getSessionFromTokens("a", "")).rejects.toThrow("Refresh token is required");
   });
 
   it("signOutWithTokens continues when setSession fails but signOut succeeds", async () => {
@@ -156,6 +184,11 @@ describe("auth service unit", () => {
     await expect(signOutWithTokens("a", "r")).rejects.toThrow("Failed to sign out: cannot signout");
   });
 
+  it("validates signOutWithTokens required fields", async () => {
+    await expect(signOutWithTokens("", "r")).rejects.toThrow("Access token is required");
+    await expect(signOutWithTokens("a", "")).rejects.toThrow("Refresh token is required");
+  });
+
   it("refreshSession throws on error or missing user", async () => {
     authMock.refreshSession.mockResolvedValueOnce({ data: { user: null, session: null }, error: { message: "bad token" } });
     await expect(refreshSession("r")).rejects.toThrow("Failed to refresh session: bad token");
@@ -164,12 +197,23 @@ describe("auth service unit", () => {
     await expect(refreshSession("r")).rejects.toThrow("Session refresh did not return a user");
   });
 
+  it("validates refreshSession required fields", async () => {
+    await expect(refreshSession("")) .rejects.toThrow("Refresh token is required");
+  });
+
   it("updatePassword throws for setSession and updateUser failures", async () => {
     authMock.setSession.mockResolvedValueOnce({ data: { user: null, session: null }, error: { message: "bad" } });
     await expect(updatePassword("a", "r", "newpassword")).rejects.toThrow("Failed to set session: bad");
 
     authMock.updateUser.mockResolvedValueOnce({ error: { message: "weak" } });
     await expect(updatePassword("a", "r", "newpassword")).rejects.toThrow("Failed to update password: weak");
+  });
+
+  it("validates updatePassword required fields and minimum length", async () => {
+    await expect(updatePassword("", "r", "newpassword")).rejects.toThrow("Access token is required");
+    await expect(updatePassword("a", "", "newpassword")).rejects.toThrow("Refresh token is required");
+    await expect(updatePassword("a", "r", "")).rejects.toThrow("New password is required");
+    await expect(updatePassword("a", "r", "123")).rejects.toThrow("Password must be at least 6 characters");
   });
 
   it("completePasswordReset throws for exchange/update failures", async () => {
@@ -181,6 +225,12 @@ describe("auth service unit", () => {
 
     authMock.updateUser.mockResolvedValueOnce({ error: { message: "reject" } });
     await expect(completePasswordReset("code", "Password123")).rejects.toThrow("Failed to update password: reject");
+  });
+
+  it("validates completePasswordReset required fields and minimum length", async () => {
+    await expect(completePasswordReset("", "Password123")).rejects.toThrow("Reset token is required");
+    await expect(completePasswordReset("token", "")).rejects.toThrow("Password is required");
+    await expect(completePasswordReset("token", "123")).rejects.toThrow("Password must be at least 6 characters");
   });
 
   it("ensureFreshSession throws when refresh has error or no session", async () => {
@@ -203,5 +253,9 @@ describe("auth service unit", () => {
     expect(authMock.resetPasswordForEmail).toHaveBeenCalledWith("user@school.edu", {
       redirectTo: "https://example.com/reset",
     });
+  });
+
+  it("validates sendPasswordResetEmail required fields", async () => {
+    await expect(sendPasswordResetEmail("")).rejects.toThrow("Email is required");
   });
 });

--- a/apps/backend/src/services/__tests__/blocks.unit.test.ts
+++ b/apps/backend/src/services/__tests__/blocks.unit.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type QueryOperation = "select" | "insert" | "delete";
+
+type QueryResponse = {
+  table: string;
+  operation: QueryOperation;
+  data?: unknown;
+  error?: { message: string } | null;
+};
+
+const { state, supabaseMock } = vi.hoisted(() => {
+  const mockState = {
+    responses: [] as QueryResponse[],
+  };
+
+  function nextResponse(table: string, operation: QueryOperation) {
+    const response = mockState.responses.shift();
+
+    if (!response) {
+      throw new Error(`Unexpected query for ${table}.${operation}`);
+    }
+
+    if (response.table !== table || response.operation !== operation) {
+      throw new Error(
+        `Unexpected query order. Expected ${response.table}.${response.operation} but got ${table}.${operation}`,
+      );
+    }
+
+    return {
+      data: response.data ?? null,
+      error: response.error ?? null,
+      count: null,
+    };
+  }
+
+  function createChain(table: string) {
+    let operation: QueryOperation = "select";
+    const chain: Record<string, unknown> = {};
+
+    chain.select = () => chain;
+    chain.eq = () => chain;
+    chain.is = () => chain;
+    chain.order = () => chain;
+    chain.limit = () => chain;
+
+    chain.upsert = () => {
+      operation = "insert";
+      return chain;
+    };
+
+    chain.delete = () => {
+      operation = "delete";
+      return chain;
+    };
+
+    chain.single = async () => nextResponse(table, operation);
+
+    chain.then = (
+      resolve: (value: { data: unknown; error: { message: string } | null; count: number | null }) => unknown,
+      reject?: (reason?: unknown) => unknown,
+    ) => Promise.resolve(nextResponse(table, operation)).then(resolve, reject);
+
+    return chain;
+  }
+
+  return {
+    state: mockState,
+    supabaseMock: {
+      from: (table: string) => createChain(table),
+    },
+  };
+});
+
+function enqueueResponse(response: QueryResponse) {
+  state.responses.push(response);
+}
+
+vi.mock("../../supabase-client.js", () => ({
+  supabase: supabaseMock,
+}));
+
+import { blockUser, getBlockedUsers, isBlocked, unblockUser } from "../blocks.js";
+
+describe("blocks service unit", () => {
+  beforeEach(() => {
+    state.responses.length = 0;
+    vi.restoreAllMocks();
+  });
+
+  it("covers blockUser validation and failure branches", async () => {
+    await expect(blockUser("", "u2")).rejects.toThrow("User ID is required");
+    await expect(blockUser("u1", "")).rejects.toThrow("Blocked user ID is required");
+    await expect(blockUser("u1", "u1")).rejects.toThrow("You cannot block yourself");
+
+    enqueueResponse({ table: "blocks", operation: "insert", error: { message: "db fail" } });
+    await expect(blockUser("u1", "u2")).rejects.toThrow("Failed to block user: db fail");
+
+    enqueueResponse({ table: "blocks", operation: "insert", data: null });
+    await expect(blockUser("u1", "u2")).rejects.toThrow("Block did not return data");
+  });
+
+  it("covers unblockUser error branch", async () => {
+    await expect(unblockUser("", "u2")).rejects.toThrow("User ID is required");
+    await expect(unblockUser("u1", "")).rejects.toThrow("Blocked user ID is required");
+
+    enqueueResponse({ table: "blocks", operation: "delete", error: { message: "delete fail" } });
+    await expect(unblockUser("u1", "u2")).rejects.toThrow("Failed to unblock user: delete fail");
+  });
+
+  it("covers getBlockedUsers fallback and error branches", async () => {
+    await expect(getBlockedUsers("")).rejects.toThrow("User ID is required");
+
+    enqueueResponse({ table: "blocks", operation: "select", error: { message: "query fail" } });
+    await expect(getBlockedUsers("u1")).rejects.toThrow("Failed to fetch blocked users: query fail");
+
+    enqueueResponse({ table: "blocks", operation: "select", data: null });
+    await expect(getBlockedUsers("u1")).resolves.toEqual([]);
+  });
+
+  it("covers isBlocked validation, error, false and true branches", async () => {
+    await expect(isBlocked("", "u2")).rejects.toThrow("User ID is required");
+    await expect(isBlocked("u1", "")).rejects.toThrow("Target user ID is required");
+
+    enqueueResponse({ table: "blocks", operation: "select", error: { message: "check fail" } });
+    await expect(isBlocked("u1", "u2")).rejects.toThrow("Failed to check block status: check fail");
+
+    enqueueResponse({ table: "blocks", operation: "select", data: [] });
+    await expect(isBlocked("u1", "u2")).resolves.toBe(false);
+
+    enqueueResponse({ table: "blocks", operation: "select", data: [{ id: "b1" }] });
+    await expect(isBlocked("u1", "u2")).resolves.toBe(true);
+  });
+});

--- a/apps/backend/src/services/__tests__/listings.unit.test.ts
+++ b/apps/backend/src/services/__tests__/listings.unit.test.ts
@@ -64,6 +64,11 @@ const { state, supabaseMock } = vi.hoisted(() => {
       return chain;
     };
 
+    chain.upsert = () => {
+      operation = "insert";
+      return chain;
+    };
+
     chain.delete = () => {
       operation = "delete";
       return chain;
@@ -111,10 +116,22 @@ vi.mock("../../supabase-client.js", () => ({
 }));
 
 import {
+  createListing,
+  deleteListing,
+  deleteListingImage,
+  getListingPublishReadiness,
+  getListingsByUser,
+  getListingWithDetails,
+  getListingById,
   getListingImageUrl,
   ListingAlreadySoldError,
+  ListingPublishValidationError,
   markListingAsSold,
+  searchListings,
+  updateListing,
   uploadListingImage,
+  upsertItemDetails,
+  upsertServiceDetails,
 } from "../listings.js";
 
 describe("listings service unit", () => {
@@ -143,6 +160,11 @@ describe("listings service unit", () => {
     enqueueResponse({ table: "listings", operation: "update", data: null, error: { message: "db unstable" } });
     enqueueResponse({ table: "listings", operation: "select", data: { user_id: "u1", status: "active" } });
     await expect(markListingAsSold("l1", "u1")).rejects.toThrow("Failed to mark listing as sold: db unstable");
+  });
+
+  it("validates markListingAsSold required fields", async () => {
+    await expect(markListingAsSold("", "u1")).rejects.toThrow("Listing ID is required");
+    await expect(markListingAsSold("l1", "")).rejects.toThrow("User ID is required");
   });
 
   it("markListingAsSold warns when notification insert fails but still returns listing", async () => {
@@ -198,6 +220,272 @@ describe("listings service unit", () => {
     );
 
     expect(state.removedPaths.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("validates uploadListingImage input branches", async () => {
+    await expect(uploadListingImage("", "u1", new Uint8Array([1]), "image/png")).rejects.toThrow("Listing ID is required");
+    await expect(uploadListingImage("l1", "", new Uint8Array([1]), "image/png")).rejects.toThrow("User ID is required");
+    await expect(uploadListingImage("l1", "u1", new Uint8Array([1]), "text/plain")).rejects.toThrow(
+      "Unsupported image content type. Allowed types: image/jpeg, image/png, image/webp",
+    );
+    await expect(uploadListingImage("l1", "u1", new Uint8Array(6 * 1024 * 1024), "image/png")).rejects.toThrow(
+      "Listing image exceeds max size of 5 MB",
+    );
+    await expect(uploadListingImage("l1", "u1", new Uint8Array([1]), "image/png", { order_no: -1 })).rejects.toThrow(
+      "Listing image order_no must be a non-negative integer",
+    );
+  });
+
+  it("surfaces uploadListingImage ownership and storage upload errors", async () => {
+    enqueueResponse({ table: "listings", operation: "select", error: { message: "missing", code: "PGRST116" } });
+    await expect(uploadListingImage("l1", "u1", new Uint8Array([1]), "image/png")).rejects.toThrow(
+      "Listing not found or you do not have permission to modify it",
+    );
+
+    enqueueResponse({ table: "listings", operation: "select", error: { message: "db fail", code: "DBERR" } });
+    await expect(uploadListingImage("l1", "u1", new Uint8Array([1]), "image/png")).rejects.toThrow(
+      "Database error while verifying listing ownership: db fail",
+    );
+
+    enqueueResponse({ table: "listings", operation: "select", data: { id: "l1" } });
+    enqueueResponse({ table: "listing_images", operation: "select", data: { order_no: 0 } });
+    state.uploadError = { message: "upload failed" };
+    await expect(uploadListingImage("l1", "u1", new Uint8Array([1]), "image/png")).rejects.toThrow(
+      "Failed to upload listing image: upload failed",
+    );
+  });
+
+  it("covers getListingById failure branches", async () => {
+    await expect(getListingById("")).rejects.toThrow("Listing ID is required");
+
+    enqueueResponse({ table: "listings", operation: "select", error: { message: "query failed" } });
+    await expect(getListingById("l1")).rejects.toThrow("Failed to fetch listing: query failed");
+
+    enqueueResponse({ table: "listings", operation: "select", data: null });
+    await expect(getListingById("l1")).rejects.toThrow("Listing not found for ID: l1");
+  });
+
+  it("covers deleteListing failure branches", async () => {
+    await expect(deleteListing("", "u1")).rejects.toThrow("Listing ID is required");
+    await expect(deleteListing("l1", "")).rejects.toThrow("User ID is required");
+
+    enqueueResponse({ table: "listings", operation: "update", error: { message: "missing", code: "PGRST116" } });
+    await expect(deleteListing("l1", "u1")).rejects.toThrow("Listing not found or you do not have permission to delete it");
+
+    enqueueResponse({ table: "listings", operation: "update", error: { message: "delete failed", code: "DBERR" } });
+    await expect(deleteListing("l1", "u1")).rejects.toThrow("Failed to delete listing: delete failed");
+
+    enqueueResponse({ table: "listings", operation: "update", data: null });
+    await expect(deleteListing("l1", "u1")).rejects.toThrow("Listing not found or you do not have permission to delete it");
+  });
+
+  it("covers deleteListingImage failure branches", async () => {
+    await expect(deleteListingImage("", "u1")).rejects.toThrow("Listing image ID is required");
+    await expect(deleteListingImage("img1", "")).rejects.toThrow("User ID is required");
+
+    enqueueResponse({ table: "listing_images", operation: "select", error: { message: "not found", code: "PGRST116" } });
+    await expect(deleteListingImage("img1", "u1")).rejects.toThrow("Listing image not found or you do not have permission to delete it");
+
+    enqueueResponse({ table: "listing_images", operation: "select", data: { id: "img1", listing_id: "l1", path: "p", deleted_at: "2026" } });
+    await expect(deleteListingImage("img1", "u1")).rejects.toThrow("Listing image not found or you do not have permission to delete it");
+
+    enqueueResponse({ table: "listing_images", operation: "select", data: { id: "img1", listing_id: "l1", path: "p", deleted_at: null } });
+    enqueueResponse({ table: "listings", operation: "select", data: { id: "l1" } });
+    state.removeError = { message: "remove failed" };
+    await expect(deleteListingImage("img1", "u1")).rejects.toThrow("Failed to delete listing image object: remove failed");
+
+    state.removeError = null;
+    enqueueResponse({ table: "listing_images", operation: "select", data: { id: "img1", listing_id: "l1", path: "p", deleted_at: null } });
+    enqueueResponse({ table: "listings", operation: "select", data: { id: "l1" } });
+    enqueueResponse({ table: "listing_images", operation: "delete", error: { message: "delete fail", code: "DBERR" } });
+    await expect(deleteListingImage("img1", "u1")).rejects.toThrow("Failed to delete listing image metadata: delete fail");
+  });
+
+  it("covers searchListings query error and no-data branch", async () => {
+    enqueueResponse({ table: "listings", operation: "select", error: { message: "search failed" } });
+    await expect(searchListings({ query: "bike" })).rejects.toThrow("Failed to search listings: search failed");
+
+    enqueueResponse({ table: "listings", operation: "select", data: null });
+    await expect(searchListings({ query: "bike" })).resolves.toEqual([]);
+  });
+
+  it("covers createListing validation and persistence branches", async () => {
+    await expect(createListing({ user_id: "", title: "x" })).rejects.toThrow("Listing user_id is required");
+    await expect(createListing({ user_id: "u1", title: "" })).rejects.toThrow("Listing title is required");
+    await expect(createListing({ user_id: "u1", title: "x", price: -1 })).rejects.toThrow("Listing price cannot be negative");
+
+    enqueueResponse({ table: "listings", operation: "insert", error: { message: "insert failed" } });
+    await expect(createListing({ user_id: "u1", title: "Bike" })).rejects.toThrow("Failed to create listing: insert failed");
+
+    enqueueResponse({ table: "listings", operation: "insert", data: null });
+    await expect(createListing({ user_id: "u1", title: "Bike" })).rejects.toThrow("Listing creation did not return data");
+  });
+
+  it("covers updateListing validation and update error branches", async () => {
+    await expect(updateListing("", "u1", { title: "x" })).rejects.toThrow("Listing ID is required");
+    await expect(updateListing("l1", "", { title: "x" })).rejects.toThrow("User ID is required");
+    await expect(updateListing("l1", "u1", { title: "   " })).rejects.toThrow("Listing title cannot be empty");
+    await expect(updateListing("l1", "u1", { price: -1 })).rejects.toThrow("Listing price cannot be negative");
+    await expect(updateListing("l1", "u1", {})).rejects.toThrow("No fields provided to update");
+
+    enqueueResponse({
+      table: "listings",
+      operation: "select",
+      data: {
+        id: "l1",
+        user_id: "u1",
+        type: "item",
+        title: "",
+        description: "d",
+        price: null,
+        price_unit: null,
+        category_id: null,
+        status: "draft",
+        location: null,
+        created_at: "2026-01-01",
+        updated_at: "2026-01-01",
+        listing_images: [],
+        listing_tags: [],
+        categories: null,
+        item_details: null,
+        service_details: null,
+      },
+    });
+    await expect(updateListing("l1", "u1", { status: "active" })).rejects.toBeInstanceOf(ListingPublishValidationError);
+
+    enqueueResponse({ table: "listings", operation: "update", error: { message: "missing", code: "PGRST116" } });
+    await expect(updateListing("l1", "u1", { title: "new" })).rejects.toThrow("Listing not found or you do not have permission to update it");
+
+    enqueueResponse({ table: "listings", operation: "update", error: { message: "update fail", code: "DBERR" } });
+    await expect(updateListing("l1", "u1", { title: "new" })).rejects.toThrow("Failed to update listing: update fail");
+
+    enqueueResponse({ table: "listings", operation: "update", data: null });
+    await expect(updateListing("l1", "u1", { title: "new" })).rejects.toThrow("Listing not found or you do not have permission to update it");
+  });
+
+  it("covers getListingPublishReadiness input and ownership branches", async () => {
+    await expect(getListingPublishReadiness("", "u1")).rejects.toThrow("Listing ID is required");
+    await expect(getListingPublishReadiness("l1", "")).rejects.toThrow("User ID is required");
+
+    enqueueResponse({
+      table: "listings",
+      operation: "select",
+      data: {
+        id: "l1",
+        user_id: "u2",
+        type: "item",
+        title: "Bike",
+        description: "d",
+        price: 10,
+        price_unit: null,
+        category_id: "c1",
+        status: "draft",
+        location: "NJ",
+        created_at: "2026-01-01",
+        updated_at: "2026-01-01",
+        listing_images: [{ id: "i1", path: "p", alt_text: null, order_no: 1, deleted_at: null }],
+        listing_tags: [],
+        categories: { name: "Books" },
+        item_details: { condition: "good", quantity: 1, expires_at: null },
+        service_details: null,
+      },
+    });
+    await expect(getListingPublishReadiness("l1", "u1")).rejects.toThrow("Listing not found or you do not have permission to update it");
+  });
+
+  it("covers getListingsByUser and getListingWithDetails branches", async () => {
+    await expect(getListingsByUser("", "active")).rejects.toThrow("User ID is required");
+
+    enqueueResponse({ table: "listings", operation: "select", error: { message: "fetch failed" } });
+    await expect(getListingsByUser("u1", "active")).rejects.toThrow("Failed to fetch listings for user: fetch failed");
+
+    enqueueResponse({ table: "listings", operation: "select", data: [] });
+    await expect(getListingsByUser("u1")).resolves.toEqual([]);
+
+    await expect(getListingWithDetails("")).rejects.toThrow("Listing ID is required");
+
+    enqueueResponse({ table: "listings", operation: "select", error: { message: "missing", code: "PGRST116" } });
+    await expect(getListingWithDetails("l1")).rejects.toThrow("Listing not found for ID: l1");
+
+    enqueueResponse({ table: "listings", operation: "select", error: { message: "boom", code: "DBERR" } });
+    await expect(getListingWithDetails("l1")).rejects.toThrow("Failed to fetch listing details: boom");
+
+    enqueueResponse({ table: "listings", operation: "select", data: null });
+    await expect(getListingWithDetails("l1")).rejects.toThrow("Listing not found for ID: l1");
+
+    enqueueResponse({
+      table: "listings",
+      operation: "select",
+      data: {
+        id: "l1",
+        user_id: "u1",
+        type: "item",
+        title: "Bike",
+        description: "d",
+        price: "12.50",
+        price_unit: null,
+        category_id: "c1",
+        status: "active",
+        location: "NJ",
+        created_at: "2026-01-01",
+        updated_at: "2026-01-01",
+        listing_images: [
+          { id: "i2", path: "p2", alt_text: null, order_no: 2, deleted_at: null },
+          { id: "i1", path: "p1", alt_text: null, order_no: 1, deleted_at: null },
+          { id: "i3", path: "p3", alt_text: null, order_no: 3, deleted_at: "2026" },
+        ],
+        listing_tags: [{ tags: { id: "t1", name: "tag1" } }, { tags: null }],
+        categories: { name: "Books" },
+        item_details: { condition: "good", quantity: 1, expires_at: null },
+        service_details: null,
+      },
+    });
+
+    const details = await getListingWithDetails("l1");
+    expect(details.price).toBe(12.5);
+    expect(details.images.map((i) => i.id)).toEqual(["i1", "i2"]);
+    expect(details.tags).toEqual([{ id: "t1", name: "tag1" }]);
+    expect(details.category_name).toBe("Books");
+  });
+
+  it("covers upsert item/service detail validation and failure branches", async () => {
+    await expect(upsertItemDetails("", "u1", { condition: "good", quantity: 1, expires_at: null })).rejects.toThrow("Listing ID is required");
+    await expect(upsertItemDetails("l1", "", { condition: "good", quantity: 1, expires_at: null })).rejects.toThrow("User ID is required");
+    await expect(
+      upsertItemDetails("l1", "u1", { condition: "" as never, quantity: 1, expires_at: null }),
+    ).rejects.toThrow("Item condition is required");
+    await expect(upsertItemDetails("l1", "u1", { condition: "good", quantity: 0, expires_at: null })).rejects.toThrow("Item quantity must be at least 1");
+
+    enqueueResponse({ table: "listings", operation: "select", data: { id: "l1" } });
+    enqueueResponse({ table: "item_details", operation: "insert", error: { message: "upsert fail" } });
+    await expect(upsertItemDetails("l1", "u1", { condition: "good", quantity: 1, expires_at: null })).rejects.toThrow(
+      "Failed to upsert item details: upsert fail",
+    );
+
+    enqueueResponse({ table: "listings", operation: "select", data: { id: "l1" } });
+    enqueueResponse({ table: "item_details", operation: "insert", data: null });
+    await expect(upsertItemDetails("l1", "u1", { condition: "good", quantity: 1, expires_at: null })).rejects.toThrow(
+      "Item details upsert did not return data",
+    );
+
+    await expect(upsertServiceDetails("", "u1", { duration_minutes: 60, price_unit: "hour", available_from: null, available_to: null })).rejects.toThrow(
+      "Listing ID is required",
+    );
+    await expect(upsertServiceDetails("l1", "", { duration_minutes: 60, price_unit: "hour", available_from: null, available_to: null })).rejects.toThrow(
+      "User ID is required",
+    );
+
+    enqueueResponse({ table: "listings", operation: "select", data: { id: "l1" } });
+    enqueueResponse({ table: "service_details", operation: "insert", error: { message: "svc fail" } });
+    await expect(upsertServiceDetails("l1", "u1", { duration_minutes: 60, price_unit: "hour", available_from: null, available_to: null })).rejects.toThrow(
+      "Failed to upsert service details: svc fail",
+    );
+
+    enqueueResponse({ table: "listings", operation: "select", data: { id: "l1" } });
+    enqueueResponse({ table: "service_details", operation: "insert", data: null });
+    await expect(upsertServiceDetails("l1", "u1", { duration_minutes: 60, price_unit: "hour", available_from: null, available_to: null })).rejects.toThrow(
+      "Service details upsert did not return data",
+    );
   });
 
   it("returns public listing image url", () => {

--- a/apps/backend/src/services/__tests__/listings.unit.test.ts
+++ b/apps/backend/src/services/__tests__/listings.unit.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type QueryOperation = "select" | "insert" | "update" | "delete";
+
+type QueryResponse = {
+  table: string;
+  operation: QueryOperation;
+  data?: unknown;
+  error?: { message: string; code?: string } | null;
+};
+
+const { state, supabaseMock } = vi.hoisted(() => {
+  const mockState = {
+    responses: [] as QueryResponse[],
+    uploadError: null as { message: string } | null,
+    removeError: null as { message: string } | null,
+    removedPaths: [] as string[][],
+    publicUrl: "https://cdn.example/listing.png",
+  };
+
+  function nextResponse(table: string, operation: QueryOperation) {
+    const response = mockState.responses.shift();
+
+    if (!response) {
+      throw new Error(`Unexpected query for ${table}.${operation}`);
+    }
+
+    if (response.table !== table || response.operation !== operation) {
+      throw new Error(
+        `Unexpected query order. Expected ${response.table}.${response.operation} but got ${table}.${operation}`,
+      );
+    }
+
+    return {
+      data: response.data ?? null,
+      error: response.error ?? null,
+      count: null,
+    };
+  }
+
+  function createChain(table: string) {
+    let operation: QueryOperation = "select";
+    const chain: Record<string, unknown> = {};
+
+    chain.select = () => chain;
+    chain.eq = () => chain;
+    chain.neq = () => chain;
+    chain.is = () => chain;
+    chain.in = () => chain;
+    chain.order = () => chain;
+    chain.limit = () => chain;
+    chain.range = () => chain;
+    chain.gte = () => chain;
+    chain.lte = () => chain;
+    chain.textSearch = () => chain;
+
+    chain.insert = () => {
+      operation = "insert";
+      return chain;
+    };
+
+    chain.update = () => {
+      operation = "update";
+      return chain;
+    };
+
+    chain.delete = () => {
+      operation = "delete";
+      return chain;
+    };
+
+    chain.single = async () => nextResponse(table, operation);
+    chain.maybeSingle = async () => nextResponse(table, operation);
+
+    chain.returns = () => chain;
+
+    chain.then = (
+      resolve: (value: { data: unknown; error: { message: string; code?: string } | null; count: number | null }) => unknown,
+      reject?: (reason?: unknown) => unknown,
+    ) => Promise.resolve(nextResponse(table, operation)).then(resolve, reject);
+
+    return chain;
+  }
+
+  const mockSupabase = {
+    from: (table: string) => createChain(table),
+    storage: {
+      from: () => ({
+        upload: async () => ({ error: mockState.uploadError }),
+        remove: async (paths: string[]) => {
+          mockState.removedPaths.push(paths);
+          return { error: mockState.removeError };
+        },
+        getPublicUrl: () => ({ data: { publicUrl: mockState.publicUrl } }),
+      }),
+    },
+  };
+
+  return {
+    state: mockState,
+    supabaseMock: mockSupabase,
+  };
+});
+
+function enqueueResponse(response: QueryResponse) {
+  state.responses.push(response);
+}
+
+vi.mock("../../supabase-client.js", () => ({
+  supabase: supabaseMock,
+}));
+
+import {
+  getListingImageUrl,
+  ListingAlreadySoldError,
+  markListingAsSold,
+  uploadListingImage,
+} from "../listings.js";
+
+describe("listings service unit", () => {
+  beforeEach(() => {
+    state.responses.length = 0;
+    state.uploadError = null;
+    state.removeError = null;
+    state.removedPaths.length = 0;
+    state.publicUrl = "https://cdn.example/listing.png";
+    vi.restoreAllMocks();
+  });
+
+  it("markListingAsSold throws detailed errors on failed update path", async () => {
+    enqueueResponse({ table: "listings", operation: "update", data: null, error: { message: "update fail" } });
+    enqueueResponse({ table: "listings", operation: "select", data: null });
+    await expect(markListingAsSold("l1", "u1")).rejects.toThrow("Listing not found");
+
+    enqueueResponse({ table: "listings", operation: "update", data: null, error: { message: "update fail" } });
+    enqueueResponse({ table: "listings", operation: "select", data: { user_id: "u2", status: "active" } });
+    await expect(markListingAsSold("l1", "u1")).rejects.toThrow("Listing not found or you do not have permission to modify it");
+
+    enqueueResponse({ table: "listings", operation: "update", data: null, error: { message: "update fail" } });
+    enqueueResponse({ table: "listings", operation: "select", data: { user_id: "u1", status: "sold" } });
+    await expect(markListingAsSold("l1", "u1")).rejects.toBeInstanceOf(ListingAlreadySoldError);
+
+    enqueueResponse({ table: "listings", operation: "update", data: null, error: { message: "db unstable" } });
+    enqueueResponse({ table: "listings", operation: "select", data: { user_id: "u1", status: "active" } });
+    await expect(markListingAsSold("l1", "u1")).rejects.toThrow("Failed to mark listing as sold: db unstable");
+  });
+
+  it("markListingAsSold warns when notification insert fails but still returns listing", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    enqueueResponse({
+      table: "listings",
+      operation: "update",
+      data: {
+        id: "l1",
+        user_id: "u1",
+        type: "item",
+        title: "Bike",
+        description: "desc",
+        price: 10,
+        price_unit: null,
+        category_id: null,
+        status: "sold",
+        location: null,
+        created_at: "2026-01-01",
+        updated_at: "2026-01-01",
+      },
+    });
+    enqueueResponse({ table: "wishlists", operation: "select", data: [{ user_id: "u2" }] });
+    enqueueResponse({ table: "conversations", operation: "select", data: [] });
+    enqueueResponse({ table: "notifications", operation: "insert", error: { message: "notify fail" } });
+
+    const listing = await markListingAsSold("l1", "u1");
+
+    expect(listing.status).toBe("sold");
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("uploadListingImage surfaces order and metadata persistence errors", async () => {
+    enqueueResponse({ table: "listings", operation: "select", data: { id: "l1" } });
+    enqueueResponse({ table: "listing_images", operation: "select", error: { message: "order query failed" } });
+    await expect(uploadListingImage("l1", "u1", new Uint8Array([1]), "image/png")).rejects.toThrow(
+      "Failed to determine listing image order: order query failed",
+    );
+
+    enqueueResponse({ table: "listings", operation: "select", data: { id: "l1" } });
+    enqueueResponse({ table: "listing_images", operation: "select", data: { order_no: 1 } });
+    enqueueResponse({ table: "listing_images", operation: "insert", error: { message: "insert failed" } });
+    await expect(uploadListingImage("l1", "u1", new Uint8Array([1]), "image/png")).rejects.toThrow(
+      "Failed to save listing image metadata: insert failed",
+    );
+
+    enqueueResponse({ table: "listings", operation: "select", data: { id: "l1" } });
+    enqueueResponse({ table: "listing_images", operation: "select", data: { order_no: 1 } });
+    enqueueResponse({ table: "listing_images", operation: "insert", data: null });
+    await expect(uploadListingImage("l1", "u1", new Uint8Array([1]), "image/png")).rejects.toThrow(
+      "Listing image upload did not return metadata",
+    );
+
+    expect(state.removedPaths.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("returns public listing image url", () => {
+    state.publicUrl = "https://cdn.example/public/path.png";
+    expect(getListingImageUrl("listing/path.png")).toBe("https://cdn.example/public/path.png");
+  });
+});

--- a/apps/backend/src/services/__tests__/notifications.unit.test.ts
+++ b/apps/backend/src/services/__tests__/notifications.unit.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type QueryOperation = "select" | "update" | "delete";
+
+type QueryResponse = {
+  table: string;
+  operation: QueryOperation;
+  data?: unknown;
+  error?: { message: string } | null;
+};
+
+type RealtimeHandler = (payload: { new: unknown }) => void;
+
+const { state, supabaseMock } = vi.hoisted(() => {
+  const mockState = {
+    responses: [] as QueryResponse[],
+    realtimeHandlers: {} as Record<string, RealtimeHandler>,
+    removedChannels: [] as string[],
+  };
+
+  function nextResponse(table: string, operation: QueryOperation) {
+    const response = mockState.responses.shift();
+
+    if (!response) {
+      throw new Error(`Unexpected query for ${table}.${operation}`);
+    }
+
+    if (response.table !== table || response.operation !== operation) {
+      throw new Error(
+        `Unexpected query order. Expected ${response.table}.${response.operation} but got ${table}.${operation}`,
+      );
+    }
+
+    return {
+      data: response.data ?? null,
+      error: response.error ?? null,
+    };
+  }
+
+  function createChain(table: string) {
+    let operation: QueryOperation = "select";
+    const chain: Record<string, unknown> = {};
+
+    chain.select = () => chain;
+    chain.eq = () => chain;
+    chain.order = () => chain;
+
+    chain.update = () => {
+      operation = "update";
+      return chain;
+    };
+
+    chain.delete = () => {
+      operation = "delete";
+      return chain;
+    };
+
+    chain.single = async () => nextResponse(table, operation);
+
+    chain.then = (
+      resolve: (value: { data: unknown; error: { message: string } | null }) => unknown,
+      reject?: (reason?: unknown) => unknown,
+    ) => Promise.resolve(nextResponse(table, operation)).then(resolve, reject);
+
+    return chain;
+  }
+
+  const mockSupabase = {
+    from: (table: string) => createChain(table),
+    channel: (name: string) => {
+      const channel = {
+        name,
+        on: (_event: string, _filter: unknown, handler: RealtimeHandler) => {
+          mockState.realtimeHandlers[name] = handler;
+          return channel;
+        },
+        subscribe: () => channel,
+      };
+
+      return channel;
+    },
+    removeChannel: (channel: { name: string }) => {
+      mockState.removedChannels.push(channel.name);
+    },
+  };
+
+  return {
+    state: mockState,
+    supabaseMock: mockSupabase,
+  };
+});
+
+function enqueueResponse(response: QueryResponse) {
+  state.responses.push(response);
+}
+
+vi.mock("../../supabase-client.js", () => ({
+  supabase: supabaseMock,
+}));
+
+import {
+  deleteNotification,
+  getNotifications,
+  markAllNotificationsRead,
+  markNotificationRead,
+  subscribeToNotifications,
+} from "../notifications.js";
+
+describe("notifications service unit", () => {
+  beforeEach(() => {
+    state.responses.length = 0;
+    state.realtimeHandlers = {};
+    state.removedChannels.length = 0;
+    vi.restoreAllMocks();
+  });
+
+  it("returns empty notifications when query returns null", async () => {
+    enqueueResponse({ table: "notifications", operation: "select", data: null });
+    await expect(getNotifications("u1")).resolves.toEqual([]);
+  });
+
+  it("surfaces getNotifications query errors", async () => {
+    enqueueResponse({ table: "notifications", operation: "select", error: { message: "fetch failed" } });
+    await expect(getNotifications("u1")).rejects.toThrow("Failed to fetch notifications: fetch failed");
+  });
+
+  it("handles markNotificationRead failure and missing row", async () => {
+    enqueueResponse({ table: "notifications", operation: "update", error: { message: "update failed" } });
+    await expect(markNotificationRead("n1", "u1")).rejects.toThrow("Failed to mark notification read: update failed");
+
+    enqueueResponse({ table: "notifications", operation: "update", data: null });
+    await expect(markNotificationRead("n1", "u1")).rejects.toThrow("Notification not found or does not belong to you");
+  });
+
+  it("surfaces markAllNotificationsRead errors", async () => {
+    enqueueResponse({ table: "notifications", operation: "update", error: { message: "bulk failed" } });
+    await expect(markAllNotificationsRead("u1")).rejects.toThrow("Failed to mark all notifications read: bulk failed");
+  });
+
+  it("handles deleteNotification failure and missing row", async () => {
+    enqueueResponse({ table: "notifications", operation: "delete", error: { message: "delete failed" } });
+    await expect(deleteNotification("n1", "u1")).rejects.toThrow("Failed to delete notification: delete failed");
+
+    enqueueResponse({ table: "notifications", operation: "delete", data: null });
+    await expect(deleteNotification("n1", "u1")).rejects.toThrow("Notification not found or does not belong to you");
+  });
+
+  it("subscribes, invokes callback, and unsubscribes", () => {
+    const received: string[] = [];
+
+    const subscription = subscribeToNotifications("u1", (notification) => {
+      received.push(notification.id);
+    });
+
+    state.realtimeHandlers["notifications:u1"]?.({
+      new: {
+        id: "n1",
+        user_id: "u1",
+        type: "new_message",
+        payload: {},
+        is_read: false,
+        read_at: null,
+        created_at: "2026-01-01",
+      },
+    });
+
+    subscription.unsubscribe();
+
+    expect(received).toEqual(["n1"]);
+    expect(state.removedChannels).toContain("notifications:u1");
+  });
+});

--- a/apps/backend/src/services/__tests__/reports.test.ts
+++ b/apps/backend/src/services/__tests__/reports.test.ts
@@ -129,4 +129,30 @@ describe("reports service", () => {
     );
     await expect(createReport("reporter-1", null, "user-2", "")).rejects.toThrow("Reason is required");
   });
+
+  it("throws when reported listing is missing or deleted", async () => {
+    enqueueResponse({ table: "listings", operation: "select", data: null, error: { message: "not found" } });
+
+    await expect(createReport("reporter-1", "listing-1", null, "Spam")).rejects.toThrow(
+      "Reported listing not found or has been deleted",
+    );
+  });
+
+  it("throws when report insert fails", async () => {
+    enqueueResponse({ table: "listings", operation: "select", data: { id: "listing-1" }, error: null });
+    enqueueResponse({ table: "reports", operation: "insert", data: null, error: { message: "insert failed" } });
+
+    await expect(createReport("reporter-1", "listing-1", null, "Spam")).rejects.toThrow(
+      "Failed to create report: insert failed",
+    );
+  });
+
+  it("throws when report insert returns no data", async () => {
+    enqueueResponse({ table: "listings", operation: "select", data: { id: "listing-1" }, error: null });
+    enqueueResponse({ table: "reports", operation: "insert", data: null, error: null });
+
+    await expect(createReport("reporter-1", "listing-1", null, "Spam")).rejects.toThrow(
+      "Create report did not return data",
+    );
+  });
 });

--- a/apps/backend/src/services/__tests__/stats.unit.test.ts
+++ b/apps/backend/src/services/__tests__/stats.unit.test.ts
@@ -84,6 +84,34 @@ describe("stats service unit", () => {
     });
   });
 
+  it("defaults activeUsers to zero when users count is null", async () => {
+    enqueueResponse({ table: "listings", count: 3 });
+    enqueueResponse({ table: "listings", count: 1 });
+    enqueueResponse({ table: "profiles", count: null });
+
+    const stats = await getHomeStats();
+
+    expect(stats).toEqual({
+      activeListings: 3,
+      newToday: 1,
+      activeUsers: 0,
+    });
+  });
+
+  it("defaults activeListings to zero when active listing count is null", async () => {
+    enqueueResponse({ table: "listings", count: null });
+    enqueueResponse({ table: "listings", count: 2 });
+    enqueueResponse({ table: "profiles", count: 4 });
+
+    const stats = await getHomeStats();
+
+    expect(stats).toEqual({
+      activeListings: 0,
+      newToday: 2,
+      activeUsers: 4,
+    });
+  });
+
   it("throws for active listings count errors", async () => {
     enqueueResponse({ table: "listings", error: { message: "active failed" } });
     enqueueResponse({ table: "listings", count: 0 });

--- a/apps/backend/src/services/__tests__/stats.unit.test.ts
+++ b/apps/backend/src/services/__tests__/stats.unit.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type QueryResponse = {
+  table: string;
+  data?: unknown;
+  error?: { message: string } | null;
+  count?: number | null;
+};
+
+const { state, supabaseMock } = vi.hoisted(() => {
+  const mockState = {
+    responses: [] as QueryResponse[],
+  };
+
+  function nextResponse(table: string) {
+    const response = mockState.responses.shift();
+
+    if (!response) {
+      throw new Error(`Unexpected query for ${table}`);
+    }
+
+    if (response.table !== table) {
+      throw new Error(`Unexpected query order. Expected ${response.table} but got ${table}`);
+    }
+
+    return {
+      data: response.data ?? null,
+      error: response.error ?? null,
+      count: response.count ?? null,
+    };
+  }
+
+  function createChain(table: string) {
+    const chain: Record<string, unknown> = {};
+
+    chain.select = () => chain;
+    chain.eq = () => chain;
+    chain.is = () => chain;
+    chain.gte = () => chain;
+
+    chain.then = (
+      resolve: (value: { data: unknown; error: { message: string } | null; count: number | null }) => unknown,
+      reject?: (reason?: unknown) => unknown,
+    ) => Promise.resolve(nextResponse(table)).then(resolve, reject);
+
+    return chain;
+  }
+
+  return {
+    state: mockState,
+    supabaseMock: {
+      from: (table: string) => createChain(table),
+    },
+  };
+});
+
+function enqueueResponse(response: QueryResponse) {
+  state.responses.push(response);
+}
+
+vi.mock("../../supabase-client.js", () => ({
+  supabase: supabaseMock,
+}));
+
+import { getHomeStats } from "../stats.js";
+
+describe("stats service unit", () => {
+  beforeEach(() => {
+    state.responses.length = 0;
+    vi.restoreAllMocks();
+  });
+
+  it("returns computed counts and defaults null counts to zero", async () => {
+    enqueueResponse({ table: "listings", count: 12 });
+    enqueueResponse({ table: "listings", count: null });
+    enqueueResponse({ table: "profiles", count: 7 });
+
+    const stats = await getHomeStats();
+
+    expect(stats).toEqual({
+      activeListings: 12,
+      newToday: 0,
+      activeUsers: 7,
+    });
+  });
+
+  it("throws for active listings count errors", async () => {
+    enqueueResponse({ table: "listings", error: { message: "active failed" } });
+    enqueueResponse({ table: "listings", count: 0 });
+    enqueueResponse({ table: "profiles", count: 0 });
+
+    await expect(getHomeStats()).rejects.toThrow("Failed to count active listings: active failed");
+  });
+
+  it("throws for newToday count errors", async () => {
+    enqueueResponse({ table: "listings", count: 10 });
+    enqueueResponse({ table: "listings", error: { message: "today failed" } });
+    enqueueResponse({ table: "profiles", count: 5 });
+
+    await expect(getHomeStats()).rejects.toThrow("Failed to count today's listings: today failed");
+  });
+
+  it("throws for users count errors", async () => {
+    enqueueResponse({ table: "listings", count: 10 });
+    enqueueResponse({ table: "listings", count: 2 });
+    enqueueResponse({ table: "profiles", error: { message: "users failed" } });
+
+    await expect(getHomeStats()).rejects.toThrow("Failed to count users: users failed");
+  });
+});


### PR DESCRIPTION
This PR completes the current backend testing slice by improving test reliability and increasing coverage to pass the strict global gate, with a focus on branch coverage.

## What Changed
1. Stabilized integration test user setup under Supabase signup throttling.
2. Added targeted unit tests for high-branch backend service paths.
3. Expanded validation/error-path coverage for existing services.

## Key File Changes
1. Shared test helper fallback for rate-limit scenarios:
helpers.ts

2. Expanded auth branch validation tests:
auth.unit.test.ts

3. Expanded listings branch and error-path tests:
listings.unit.test.ts

4. Added blocks unit tests:
blocks.unit.test.ts

5. Expanded stats branch coverage:
stats.unit.test.ts

6. Expanded reports error-path coverage:
reports.test.ts