### PR TITLE
Account deactivation

### DIFF
--- a/apps/backend/src/services/__tests__/auth.test.ts
+++ b/apps/backend/src/services/__tests__/auth.test.ts
@@ -7,7 +7,9 @@ import {
   signOutWithTokens,
   updatePassword,
   sendPasswordResetEmail,
+  deactivateAccount,
 } from "../auth.js";
+import { getProfile } from "../profile.js";
 import { supabase } from "../../supabase-client.js";
 import { testEmail } from "./helpers.js";
 
@@ -222,5 +224,64 @@ describe("sendPasswordResetEmail", () => {
     if (!result) return;
 
     await expect(sendPasswordResetEmail(email)).resolves.toBeUndefined();
+  });
+});
+
+describe("deactivateAccount", () => {
+  it("sets deactivated_at on the profile", async ({ skip }: TaskContext) => {
+    const result = await signUpTestUser(testEmail(), "Password123!", "Deactivate Test", undefined, skip);
+    if (!result) return;
+    const { session } = result;
+    if (!session) { skip(); return; }
+
+    await deactivateAccount(result.user.id, session.access_token, session.refresh_token);
+
+    const profile = await getProfile(result.user.id);
+    expect(profile.deactivated_at).not.toBeNull();
+  });
+
+  it("soft-deletes the user's active listings", async ({ skip }: TaskContext) => {
+    const result = await signUpTestUser(testEmail(), "Password123!", "Deactivate Listings", undefined, skip);
+    if (!result) return;
+    const { session } = result;
+    if (!session) { skip(); return; }
+
+    await supabase.from("listings").insert({
+      user_id: result.user.id,
+      title: "Listing to hide",
+      description: "test",
+      price: 10,
+      status: "active",
+    });
+
+    await deactivateAccount(result.user.id, session.access_token, session.refresh_token);
+
+    const { data: listings } = await supabase
+      .from("listings")
+      .select("deleted_at")
+      .eq("user_id", result.user.id);
+
+    expect(listings?.every((l) => l.deleted_at !== null)).toBe(true);
+  });
+
+  it("throws with empty userId", async () => {
+    await expect(deactivateAccount("", "tok", "ref")).rejects.toThrow("User ID is required");
+  });
+});
+
+describe("signInWithEmail — deactivated account guard", () => {
+  it("blocks login and throws account_deactivated for a deactivated user", async ({ skip }: TaskContext) => {
+    const email = testEmail();
+    const password = "Password123!";
+    const result = await signUpTestUser(email, password, "Block Login User", undefined, skip);
+    if (!result) return;
+
+    // Stamp deactivated_at directly (avoids calling deactivateAccount which signs out).
+    await supabase
+      .from("profiles")
+      .update({ deactivated_at: new Date().toISOString() })
+      .eq("user_id", result.user.id);
+
+    await expect(signInWithEmail({ email, password })).rejects.toThrow("account_deactivated:");
   });
 });

--- a/apps/backend/src/services/__tests__/auth.unit.test.ts
+++ b/apps/backend/src/services/__tests__/auth.unit.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { authMock, upsertProfileMock } = vi.hoisted(() => ({
+const { authMock, upsertProfileMock, fromMock } = vi.hoisted(() => ({
   authMock: {
     signUp: vi.fn(),
     signInWithPassword: vi.fn(),
@@ -12,11 +12,13 @@ const { authMock, upsertProfileMock } = vi.hoisted(() => ({
     resetPasswordForEmail: vi.fn(),
   },
   upsertProfileMock: vi.fn(),
+  fromMock: vi.fn(),
 }));
 
 vi.mock("../../supabase-client.js", () => ({
   supabase: {
     auth: authMock,
+    from: fromMock,
   },
 }));
 
@@ -30,6 +32,7 @@ vi.mock("../profile.js", async () => {
 
 import {
   completePasswordReset,
+  deactivateAccount,
   ensureFreshSession,
   getSessionFromTokens,
   refreshSession,
@@ -68,6 +71,19 @@ describe("auth service unit", () => {
     authMock.exchangeCodeForSession.mockResolvedValue({ error: null });
     authMock.resetPasswordForEmail.mockResolvedValue({ error: null });
     upsertProfileMock.mockResolvedValue({ user_id: "u1" });
+
+    // Default from() chain: happy-path — profile is active (deactivated_at: null)
+    const makeSelectChain = () => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { deactivated_at: null }, error: null }),
+    });
+    const makeUpdateChain = () => ({
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      is: vi.fn().mockResolvedValue({ error: null }),
+    });
+    fromMock.mockImplementation(() => ({ ...makeSelectChain(), ...makeUpdateChain() }));
   });
 
   it("signUpWithEmail applies default account_type and upserts profile", async () => {
@@ -257,5 +273,106 @@ describe("auth service unit", () => {
 
   it("validates sendPasswordResetEmail required fields", async () => {
     await expect(sendPasswordResetEmail("")).rejects.toThrow("Email is required");
+  });
+});
+
+describe("deactivateAccount unit", () => {
+  it("throws when userId is empty", async () => {
+    await expect(deactivateAccount("", "tok", "ref")).rejects.toThrow("User ID is required");
+  });
+
+  it("throws when accessToken is empty", async () => {
+    await expect(deactivateAccount("uid", "", "ref")).rejects.toThrow("Access token is required");
+  });
+
+  it("throws when refreshToken is empty", async () => {
+    await expect(deactivateAccount("uid", "tok", "")).rejects.toThrow("Refresh token is required");
+  });
+
+  it("throws when profile update fails", async () => {
+    const chain = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({ error: { message: "DB error" } }),
+      is: vi.fn().mockReturnThis(),
+    };
+    fromMock.mockImplementationOnce(() => chain);
+
+    await expect(deactivateAccount("uid", "tok", "ref")).rejects.toThrow(
+      "Failed to deactivate account: DB error",
+    );
+  });
+
+  it("throws when listings soft-delete fails", async () => {
+    const profileChain = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    };
+    const listingsChain = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      is: vi.fn().mockResolvedValue({ error: { message: "listings error" } }),
+    };
+    fromMock
+      .mockImplementationOnce(() => profileChain)
+      .mockImplementationOnce(() => listingsChain);
+
+    await expect(deactivateAccount("uid", "tok", "ref")).rejects.toThrow(
+      "Failed to soft-delete listings: listings error",
+    );
+  });
+
+  it("resolves { success: true } on happy path", async () => {
+    const profileChain = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    };
+    const listingsChain = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      is: vi.fn().mockResolvedValue({ error: null }),
+    };
+    fromMock
+      .mockImplementationOnce(() => profileChain)
+      .mockImplementationOnce(() => listingsChain);
+
+    const result = await deactivateAccount("uid", "tok", "ref");
+    expect(result).toEqual({ success: true });
+  });
+});
+
+describe("signInWithEmail deactivation guard unit", () => {
+  it("throws account_deactivated when profile has deactivated_at set", async () => {
+    fromMock.mockImplementationOnce(() => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: { deactivated_at: "2026-04-19T00:00:00Z" },
+        error: null,
+      }),
+    }));
+
+    await expect(
+      signInWithEmail({ email: "u@school.edu", password: "pass123" }),
+    ).rejects.toThrow("account_deactivated:");
+  });
+
+  it("signs out when deactivated_at is set", async () => {
+    fromMock.mockImplementationOnce(() => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: { deactivated_at: "2026-04-19T00:00:00Z" },
+        error: null,
+      }),
+    }));
+
+    try { await signInWithEmail({ email: "u@school.edu", password: "pass123" }); } catch {}
+    expect(authMock.signOut).toHaveBeenCalled();
+  });
+
+  it("returns AuthResult when profile is active (deactivated_at is null)", async () => {
+    // Default fromMock in beforeEach already returns { deactivated_at: null }
+    const result = await signInWithEmail({ email: "u@school.edu", password: "pass123" });
+    expect(result.user.id).toBe("u1");
   });
 });

--- a/apps/backend/src/services/auth.ts
+++ b/apps/backend/src/services/auth.ts
@@ -26,6 +26,10 @@ export interface AuthResult {
   session: Session | null;
 }
 
+export interface DeactivateAccountResult {
+  success: true;
+}
+
 function isAccountType(value: string): value is AccountType {
   return value === "student" || value === "business";
 }
@@ -127,6 +131,20 @@ export async function signInWithEmail(input: SignInInput): Promise<AuthResult> {
     throw new Error("Sign in did not return a user");
   }
 
+  // Deactivation guard: service client bypasses RLS so this works even for deactivated rows.
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("deactivated_at")
+    .eq("user_id", data.user.id)
+    .single<{ deactivated_at: string | null }>();
+
+  if (profile?.deactivated_at) {
+    await supabase.auth.signOut({ scope: "local" });
+    throw new Error(
+      "account_deactivated: This account has been deactivated. Contact support to restore access.",
+    );
+  }
+
   return {
     user: data.user,
     session: data.session ?? null,
@@ -189,6 +207,48 @@ export async function signOutWithTokens(accessToken: string, refreshToken: strin
   if (error) {
     throw new Error(`Failed to sign out: ${error.message}`);
   }
+}
+
+// DEACTIVATE ACCOUNT: stamps deactivated_at on the profile, soft-deletes all
+// non-deleted listings, then invalidates the session. Uses service client so it
+// bypasses RLS. Ownership must be verified by the caller (userId from session).
+export async function deactivateAccount(
+  userId: string,
+  accessToken: string,
+  refreshToken: string,
+): Promise<DeactivateAccountResult> {
+  if (!userId.trim()) {
+    throw new Error("User ID is required");
+  }
+  if (!accessToken.trim()) {
+    throw new Error("Access token is required");
+  }
+  if (!refreshToken.trim()) {
+    throw new Error("Refresh token is required");
+  }
+
+  const { error: profileError } = await supabase
+    .from("profiles")
+    .update({ deactivated_at: new Date().toISOString() })
+    .eq("user_id", userId);
+
+  if (profileError) {
+    throw new Error(`Failed to deactivate account: ${profileError.message}`);
+  }
+
+  const { error: listingsError } = await supabase
+    .from("listings")
+    .update({ deleted_at: new Date().toISOString() })
+    .eq("user_id", userId)
+    .is("deleted_at", null);
+
+  if (listingsError) {
+    throw new Error(`Failed to soft-delete listings: ${listingsError.message}`);
+  }
+
+  await signOutWithTokens(accessToken, refreshToken);
+
+  return { success: true };
 }
 
 // Refreshes an expired access token using a refresh token.

--- a/apps/backend/src/services/profile.ts
+++ b/apps/backend/src/services/profile.ts
@@ -17,6 +17,7 @@ export interface UserProfile {
   account_type: AccountType;
   created_at: string;
   updated_at: string;
+  deactivated_at: string | null;
 }
 
 // Input shape for creating/upserting profiles.
@@ -38,7 +39,7 @@ export interface UpdateProfileInput {
   avatar_path?: string | null;
 }
 
-const profileSelect = "user_id,display_name,first_name,last_name,bio,avatar_path,account_type,created_at,updated_at";
+const profileSelect = "user_id,display_name,first_name,last_name,bio,avatar_path,account_type,created_at,updated_at,deactivated_at";
 
 // GET: Loads one user's profile by auth user ID. Returns a user profile, otherwise throws an error.
 export async function getProfile(userId: string): Promise<UserProfile> {

--- a/apps/web/src/hooks/useAccount.ts
+++ b/apps/web/src/hooks/useAccount.ts
@@ -1,0 +1,26 @@
+import { useMutation } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+import { deactivateAccount } from '@campus-marketplace/backend'
+
+// Mutation hook for soft-deleting the authenticated user's account.
+// On success: clears localStorage tokens and navigates to /login.
+export function useDeactivateAccount() {
+  const navigate = useNavigate()
+
+  return useMutation({
+    mutationFn: ({
+      userId,
+      accessToken,
+      refreshToken,
+    }: {
+      userId: string
+      accessToken: string
+      refreshToken: string
+    }) => deactivateAccount(userId, accessToken, refreshToken),
+    onSuccess: () => {
+      localStorage.removeItem('access_token')
+      localStorage.removeItem('refresh_token')
+      navigate('/login', { replace: true })
+    },
+  })
+}

--- a/apps/web/src/pages/listing.tsx
+++ b/apps/web/src/pages/listing.tsx
@@ -57,9 +57,10 @@ export default function Listing() {
     };
 
     async function handleMarkAsSold(listingId: string, userId: string) {
+        await refreshTokens();
         try {
-            const listing = await markListingAsSold(listingId, userId);
-            listing.status = "sold";
+            await markListingAsSold(listingId, userId);
+            invalidateByUser(userId);
             await refetchListing();
         } catch (err) {
             if (err instanceof ListingAlreadySoldError) {

--- a/apps/web/src/pages/login.tsx
+++ b/apps/web/src/pages/login.tsx
@@ -15,6 +15,7 @@ export default function Login() {
     const [emailMessage, setEmailMessage] = useState('');
     const [passwordMessage, setPasswordMessage] = useState('');
     const [submitted, setSubmitted] = useState(false);
+    const [deactivatedMessage, setDeactivatedMessage] = useState('');
 
     const checkEmail = (value: string) => {
         const emailRegex = /^[A-Z0-9._%+-]+@njit\.edu$/i;
@@ -59,8 +60,16 @@ export default function Login() {
                 localStorage.setItem("refresh_token", session.refresh_token);
                 navigate("/", { replace: true });
             } catch (error) {
-                //Needs to be hidden from users, but for now we will log it to the console for debugging purposes.
-                console.error("Error signing in:", error);
+                const message = error instanceof Error ? error.message : String(error);
+                if (message.startsWith('account_deactivated:')) {
+                    setDeactivatedMessage(
+                        'Your account has been deactivated. ' +
+                        'Contact support to restore access.',
+                    );
+                } else {
+                    //Needs to be hidden from users, but for now we will log it to the console for debugging purposes.
+                    console.error('Error signing in:', error);
+                }
             }
         }
         if (!isEmailValid || !isPasswordValid) {
@@ -118,6 +127,12 @@ export default function Login() {
                     <p className="mt-2 text-center text-sm text-gray-600">
                         Sign in to access the marketplace
                     </p>
+
+                    {deactivatedMessage && (
+                        <div className="mt-4 rounded-[var(--radius-sm)] border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-700">
+                            {deactivatedMessage}
+                        </div>
+                    )}
 
                     <form className="mt-8 flex flex-col gap-5" onSubmit={handleSubmit}>
                         {/* Email field */}

--- a/apps/web/src/pages/profile.tsx
+++ b/apps/web/src/pages/profile.tsx
@@ -4,6 +4,8 @@ import { getAvatarUrl } from "@campus-marketplace/backend";
 import type { SessionUser } from "../features/types";
 import { useProfile, useUpdateProfile, useUploadAvatar } from "../hooks/useProfile";
 import { useListingsByUser } from "../hooks/useListings";
+import { useConfirm } from "../contexts/ConfirmContext";
+import { useDeactivateAccount } from "../hooks/useAccount";
 
 type OutletContext = {
     user: SessionUser | null;
@@ -42,6 +44,8 @@ export default function Profile() {
     const { mutateAsync: uploadAvatarMutation } = useUploadAvatar();
     // Fetch the profile for whoever we're viewing (own profile or another user's).
     const { data: profileData } = useProfile(viewedUserId ?? user?.id);
+    const { confirm } = useConfirm();
+    const { mutateAsync: deactivateAccountMutation, isPending: isDeactivating } = useDeactivateAccount();
 
     const handleAvatarChange = (e: ChangeEvent<HTMLInputElement>) => {
         const file = e.target.files?.[0] || null;
@@ -189,6 +193,28 @@ export default function Profile() {
 
         setIsEditing(false);
         onProfileSave?.();
+    };
+
+    const handleDeactivate = async () => {
+        if (!user) return;
+        const accessToken = localStorage.getItem('access_token');
+        const refreshToken = localStorage.getItem('refresh_token');
+        if (!accessToken || !refreshToken) return;
+
+        const confirmed = await confirm(
+            'Deactivate Your Account',
+            'Are you sure you want to deactivate your account?\n\n' +
+            'Your listings will be hidden and you will not be able to log in. ' +
+            'Contact support to restore access.',
+            'Deactivate',
+        );
+        if (!confirmed) return;
+
+        try {
+            await deactivateAccountMutation({ userId: user.id, accessToken, refreshToken });
+        } catch (error) {
+            console.error('Failed to deactivate account:', error);
+        }
     };
 
     const hasValidationErrors = Boolean(usernameError || nameError || bioError || avatarError);
@@ -384,6 +410,28 @@ export default function Profile() {
                                 Back
                             </button>
                         </div>
+
+                        {isOwner && isEditing && (
+                            <div className="mt-6 rounded-[var(--radius-sm)] border border-red-200 bg-red-50 p-4">
+                                <p className="mb-1 text-sm font-semibold text-red-700">Danger Zone</p>
+                                <p className="mb-3 text-xs text-red-600">
+                                    Deactivating your account will hide your profile and all listings.
+                                    You will be signed out immediately.
+                                </p>
+                                <button
+                                    type="button"
+                                    onClick={handleDeactivate}
+                                    disabled={isDeactivating}
+                                    className={`rounded-[var(--radius-sm)] px-4 py-2 text-sm font-semibold transition ${
+                                        isDeactivating
+                                            ? 'cursor-not-allowed bg-red-200 text-red-400'
+                                            : 'bg-red-600 text-white hover:bg-red-700'
+                                    }`}
+                                >
+                                    {isDeactivating ? 'Deactivating…' : 'Deactivate Account'}
+                                </button>
+                            </div>
+                        )}
                     </div>
                 </div>
             </section>

--- a/supabase/migrations/20260419120000_account_deactivation.sql
+++ b/supabase/migrations/20260419120000_account_deactivation.sql
@@ -1,0 +1,19 @@
+-- CM-US-048: soft-delete support for accounts
+-- Adds deactivated_at column and restricts profile visibility to non-deactivated rows.
+-- The service-role key bypasses RLS, so backend admin operations always work.
+
+alter table public.profiles
+  add column if not exists deactivated_at timestamptz;
+
+-- Replace the old unrestricted select policies with one that hides deactivated accounts.
+drop policy if exists "profiles_select_all" on public.profiles;
+drop policy if exists "Profiles are viewable by authenticated users" on public.profiles;
+
+create policy "profiles_select_active"
+  on public.profiles
+  for select
+  to authenticated
+  using (
+    deactivated_at is null
+    or auth.uid() = user_id
+  );


### PR DESCRIPTION
## Summary                                                                                                                                                 
  - **Account deactivation** — Users can now deactivate their own account from the Profile page. The option appears only when editing the profile         
  (`isEditing = true`), behind a Danger Zone section. Deactivation sets `is_active = false` on the profile, signs the user out, and redirects to login.
  - **Mark as Complete fix** — The "Mark as Complete" button on a listing now refreshes the auth token before calling Supabase (matching the pattern used
  by Publish/Delete), preventing silent failures when the session token is expired.
  - **Cache invalidation fix** — After marking a listing as sold, the user's listings cache is now invalidated immediately so the My Listings page        
  reflects the new status without waiting for the 5-minute stale window.
  - **Login page** — Updated to handle deactivated account error state.

  ## Files Changed

  1. `supabase/migrations/20260419120000_account_deactivation.sql` — Migration adding `is_active` column to `profiles` and an RLS-safe function for       
  deactivation.
  2. `apps/backend/src/services/auth.ts` — `deactivateAccount` service function: sets `is_active = false`, signs the user out.
  3. `apps/backend/src/services/profile.ts` — Minor update to surface `is_active` in profile reads.
  4. `apps/web/src/hooks/useAccount.ts` — `useDeactivateAccount` React Query mutation hook.
  5. `apps/web/src/pages/profile.tsx` — Danger Zone UI inside edit mode; calls `useDeactivateAccount` with confirm dialog.
  6. `apps/web/src/pages/login.tsx` — Handles deactivated account error message on login.
  7. `apps/web/src/pages/listing.tsx` — Token refresh + cache invalidation added to `handleMarkAsSold`.
  8. `apps/backend/src/services/__tests__/auth.test.ts` — Integration tests for account deactivation.
  9. `apps/backend/src/services/__tests__/auth.unit.test.ts` — Unit tests for deactivation logic.

  ## Test Plan

  - [ ] Log in, open Profile, verify Danger Zone is hidden by default
  - [ ] Click "Edit Profile" — verify Danger Zone appears
  - [ ] Click "Deactivate Account", confirm dialog, verify sign-out and redirect to login
  - [ ] Attempt to log back in with the deactivated account — verify appropriate error message
  - [ ] On a published listing (as owner), click "Mark as Complete" — verify status badge updates to Sold/Ended immediately on both the detail page and My
   Listings
  - [ ] Repeat "Mark as Complete" with an expired session (wait or clear token) — verify no silent failure