### PR TITLE
Fix/bugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,11 +55,12 @@ Verify no leaks: `grep -r "@supabase/supabase-js" apps/web/src/` must return not
 
 Services live in `apps/backend/src/services/`:
 - `auth.ts` — sign-up, sign-in, session restore, sign-out, password reset (fully implemented)
-- `profile.ts` — get/upsert/update profiles (fully implemented)
+- `profile.ts` — get/upsert/update profiles, avatar upload (fully implemented)
 - `theme.ts` — fetch school branding by school code (fully implemented)
 - `listings.ts` — CRUD + search for listings (fully implemented); types in `listings.types.ts`
-- `messaging.ts` — stub, not yet implemented
-- `search.ts` — stub, not yet implemented
+- `messaging.ts` — conversations, messages, realtime subscriptions (fully implemented)
+- `notifications.ts` — fetch and mark notifications read (fully implemented)
+- `wishlist.ts` — add/remove/query wishlist entries (fully implemented)
 
 All services are re-exported from `apps/backend/src/index.ts`.
 
@@ -69,7 +70,7 @@ Pages are in `apps/web/src/pages/`. All routes are wrapped in `<SidebarLayout />
 
 ### Theming (CSS Variables)
 
-School-specific branding is stored in the `school_themes` database table. The backend fetches it by `VITE_SCHOOL_CODE`; the frontend applies it as CSS variables at startup:
+School branding is stored in the `school_themes` database table and fetched by the backend using `VITE_SCHOOL_CODE`; the frontend applies it as CSS variables at startup:
 
 ```
 --color-primary, --color-secondary, --color-accent, --font-family, --logo-url, --button-style
@@ -81,11 +82,11 @@ Verify: `grep -rE "bg-\[#|text-\[#" apps/web/src/` must return nothing.
 
 ## Database
 
-Schema: `supabase/migrations/20260315120000_core_tables.sql` — 16 tables.
+Schema starts in `supabase/migrations/20260315120000_core_tables.sql` — currently **14 active tables** (favorites and school_themes were dropped in migration 20260408120000).
 
-Key tables: `profiles`, `listings`, `item_details`, `service_details`, `listing_images`, `listing_tags`, `categories`, `tags`, `conversations`, `conversation_participants`, `messages`, `notifications`, `favorites`, `reports`, `blocks`, `school_themes`.
+Key tables: `profiles`, `listings`, `item_details`, `service_details`, `listing_images`, `listing_tags`, `categories`, `tags`, `conversations`, `conversation_participants`, `messages`, `notifications`, `reports`, `blocks`, `wishlists`.
 
-All tables use UUIDs and auto-managed `updated_at` via trigger. Soft deletes (`deleted_at`) are present on `listings`, `item_details`, `service_details`, `listing_images`, `conversations`, `messages`, `categories`, and `tags` — but not on all tables.
+All tables use UUIDs. `updated_at` triggers exist on `profiles`, `listings`, `item_details`, `service_details`, `conversations`, and `reports`. Soft deletes (`deleted_at`) are present on `listings`, `item_details`, `service_details`, `listing_images`, `conversations`, `messages`, `categories`, and `tags`.
 
 **Migration rule:** Never edit existing migration files. Create new timestamped files for schema changes.
 

--- a/apps/backend/src/services/profile.ts
+++ b/apps/backend/src/services/profile.ts
@@ -106,6 +106,8 @@ export async function upsertProfile(input: UpsertProfileInput): Promise<UserProf
   return data;
 }
 
+const ALLOWED_AVATAR_TYPES = ["image/jpeg", "image/png", "image/webp"] as const;
+
 // UPLOAD AVATAR: Uploads a file to Supabase Storage under avatars/<userId>/avatar.<ext>,
 // then persists the storage path to the profile row. Returns the updated profile.
 export async function uploadAvatar(userId: string,file: File | Blob | ArrayBuffer,contentType: string): Promise<UserProfile> {
@@ -113,7 +115,11 @@ export async function uploadAvatar(userId: string,file: File | Blob | ArrayBuffe
     throw new Error("Profile user_id is required");
   }
 
-  const ext = contentType.split("/")[1] ?? "jpg"; // Default to jpg if content type is missing
+  if (!ALLOWED_AVATAR_TYPES.includes(contentType as (typeof ALLOWED_AVATAR_TYPES)[number])) {
+    throw new Error("Unsupported avatar content type. Use JPEG, PNG, or WebP.");
+  }
+
+  const ext = contentType.split("/")[1]; // jpeg | png | webp
   const storagePath = `${userId}/avatar.${ext}`; //creates storage path like "12345/avatar.jpg"
 
   // Supabase Storage upsert: if the file already exists, it will be overwritten with the new one

--- a/apps/backend/src/services/theme.ts
+++ b/apps/backend/src/services/theme.ts
@@ -65,5 +65,9 @@ export async function getThemeBySchoolCode(schoolCode: number): Promise<SchoolTh
     );
   }
 
+  if (!data) {
+    throw new Error(`No theme found for school code "${schoolCode}"`);
+  }
+
   return data;
 }

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>web</title>
+    <title>NJIT Marketplace</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@700&display=swap" rel="stylesheet" />

--- a/apps/web/public/favicon.svg
+++ b/apps/web/public/favicon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
+  <circle cx="20" cy="20" r="20" fill="#99040B"/>
+  <path d="M 10 16 L 8 30 C 8 31 9 32 10 32 L 30 32 C 31 32 32 31 32 30 L 30 16 Z" fill="white" stroke="white" stroke-width="0.5"/>
+  <path d="M 12 14 C 12 10 14.5 8 20 8 C 25.5 8 28 10 28 14" fill="none" stroke="white" stroke-width="3" stroke-linecap="round"/>
+  <circle cx="15.5" cy="22" r="1.6" fill="#780006"/>
+  <circle cx="24.5" cy="22" r="1.6" fill="#780006"/>
+  <path d="M 14.5 25.5 Q 20 28.5 25.5 25.5" fill="none" stroke="#780006" stroke-width="2" stroke-linecap="round"/>
+  <path d="M 10 28 L 8 30 C 8 31 9 32 10 32 L 30 32 C 31 32 32 31 32 30 L 30 28 Z" fill="white"/>
+</svg>

--- a/apps/web/src/components/ChatPanel.tsx
+++ b/apps/web/src/components/ChatPanel.tsx
@@ -10,6 +10,7 @@ type ChatPanelProps = {
     messageInput: string;
     onInputChange: (value: string) => void;
     onSend: () => void;
+    isSending?: boolean;
     loading: boolean;
     onBack?: () => void;
     listingId?: string | null;
@@ -33,6 +34,7 @@ export default function ChatPanel({
     messageInput,
     onInputChange,
     onSend,
+    isSending = false,
     loading,
     onBack,
     listingId,
@@ -170,7 +172,7 @@ export default function ChatPanel({
                 <button
                     type="button"
                     onClick={onSend}
-                    disabled={!messageInput.trim() || isSold}
+                    disabled={!messageInput.trim() || isSold || isSending}
                     className="flex items-center gap-2 rounded-lg bg-[var(--color-primary)] px-5 py-2.5 text-sm font-semibold text-[var(--color-text-on-primary)] disabled:opacity-40 hover:opacity-90 transition-opacity"
                 >
                     <Send size={16} />

--- a/apps/web/src/config/presets.ts
+++ b/apps/web/src/config/presets.ts
@@ -81,109 +81,13 @@ export const PRESETS: ThemePreset[] = [
     },
   },
 
-  // --- Generic ---
-  {
-    id: 'ocean',
-    name: 'Ocean',
-    category: 'generic',
-    light: {
-      primary: '#1a6eb5',
-      secondary: '#FFFFFF',
-      accent: '#93c5fd',
-      background: '#eef4fb',
-      textOnPrimary: '#FFFFFF',
-    },
-    dark: {
-      primary: '#2563eb',
-      secondary: '#0f172a',
-      accent: '#93c5fd',
-      background: '#0c1220',
-      textOnPrimary: '#FFFFFF',
-    },
-  },
-  {
-    id: 'forest',
-    name: 'Forest',
-    category: 'generic',
-    light: {
-      primary: '#2d6a4f',
-      secondary: '#FFFFFF',
-      accent: '#86efac',
-      background: '#eef7f1',
-      textOnPrimary: '#FFFFFF',
-    },
-    dark: {
-      primary: '#3a8c65',
-      secondary: '#0f1a13',
-      accent: '#86efac',
-      background: '#0c1510',
-      textOnPrimary: '#FFFFFF',
-    },
-  },
-  {
-    id: 'slate',
-    name: 'Slate',
-    category: 'generic',
-    light: {
-      primary: '#475569',
-      secondary: '#FFFFFF',
-      accent: '#94a3b8',
-      background: '#f1f5f9',
-      textOnPrimary: '#FFFFFF',
-    },
-    dark: {
-      primary: '#64748b',
-      secondary: '#0f172a',
-      accent: '#94a3b8',
-      background: '#0d1117',
-      textOnPrimary: '#FFFFFF',
-    },
-  },
-  {
-    id: 'sunset',
-    name: 'Sunset',
-    category: 'generic',
-    light: {
-      primary: '#c2410c',
-      secondary: '#FFFFFF',
-      accent: '#fdba74',
-      background: '#fdf4ee',
-      textOnPrimary: '#FFFFFF',
-    },
-    dark: {
-      primary: '#ea580c',
-      secondary: '#1a0f0a',
-      accent: '#fdba74',
-      background: '#160d08',
-      textOnPrimary: '#FFFFFF',
-    },
-  },
-  {
-    id: 'violet',
-    name: 'Violet',
-    category: 'generic',
-    light: {
-      primary: '#6d28d9',
-      secondary: '#FFFFFF',
-      accent: '#c4b5fd',
-      background: '#f5f3ff',
-      textOnPrimary: '#FFFFFF',
-    },
-    dark: {
-      primary: '#7c3aed',
-      secondary: '#0f0a1a',
-      accent: '#c4b5fd',
-      background: '#0d0a16',
-      textOnPrimary: '#FFFFFF',
-    },
-  },
 ];
 
 export const DEFAULT_PRESET_ID = 'njit-classic';
 
 // --- Radius options ---
 
-export type RadiusId = 'sharp' | 'default' | 'rounded' | 'pill';
+export type RadiusId = 'sharp' | 'default' | 'rounded';
 
 export interface RadiusOption {
   id: RadiusId;
@@ -204,13 +108,8 @@ export const RADIUS_OPTIONS: RadiusOption[] = [
   },
   {
     id: 'rounded',
-    name: 'Rounded',
+    name: 'Round',
     vars: { '--radius': '12px', '--radius-sm': '6px', '--radius-lg': '18px', '--radius-pill': '9999px' },
-  },
-  {
-    id: 'pill',
-    name: 'Pill',
-    vars: { '--radius': '9999px', '--radius-sm': '9999px', '--radius-lg': '9999px', '--radius-pill': '9999px' },
   },
 ];
 

--- a/apps/web/src/contexts/ThemeContext.tsx
+++ b/apps/web/src/contexts/ThemeContext.tsx
@@ -4,12 +4,14 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from 'react';
 import { adjustLightness, blendColors, desaturate } from '../lib/color-utils';
 import {
   LocalStoragePreferences,
+  UserLocalStoragePreferences,
   type PreferencesStorage,
   type StoredThemePrefs,
 } from '../lib/theme-storage';
@@ -39,13 +41,15 @@ function resolveMode(pref: ThemeModePreference, sysDark: boolean): ResolvedTheme
   return sysDark ? 'dark' : 'light';
 }
 
+const DEFAULT_PREFS: StoredThemePrefs = {
+  presetId: DEFAULT_PRESET_ID,
+  mode: 'system',
+  radius: DEFAULT_RADIUS_ID,
+  fontId: DEFAULT_FONT_ID,
+};
+
 function loadInitialPrefs(storage: PreferencesStorage): StoredThemePrefs {
-  return storage.load() ?? {
-    presetId: DEFAULT_PRESET_ID,
-    mode: 'system',
-    radius: DEFAULT_RADIUS_ID,
-    fontId: DEFAULT_FONT_ID,
-  };
+  return storage.load() ?? DEFAULT_PREFS;
 }
 
 function findPreset(id: string): ThemePreset {
@@ -128,19 +132,25 @@ type ThemeContextValue = {
 
   // Style controls
   radiusId: string;
-  setRadius: (radius: 'sharp' | 'default' | 'rounded' | 'pill') => void;
+  setRadius: (radius: 'sharp' | 'default' | 'rounded') => void;
   fontId: string;
   setFont: (id: string) => void;
+
+  // Auth lifecycle hooks
+  resetToDefaults: () => void;
+  loadPrefsForUser: (userId: string) => void;
 };
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 
-const storage: PreferencesStorage = new LocalStoragePreferences();
-
 export function ThemeProvider({ children }: { children: ReactNode }) {
+  // storageRef holds the active storage backend — swapped to per-user storage on login.
+  // Initialized separately from useState to avoid accessing the ref during render.
+  const storageRef = useRef<PreferencesStorage>(new LocalStoragePreferences());
+
   // Read prefs synchronously so useState is initialized with the right values —
   // prevents a flash of the default theme on load.
-  const [prefs, setPrefs] = useState<StoredThemePrefs>(() => loadInitialPrefs(storage));
+  const [prefs, setPrefs] = useState<StoredThemePrefs>(() => loadInitialPrefs(new LocalStoragePreferences()));
   const [sysDark, setSysDark] = useState(systemPrefersDark);
 
   // Listen for OS dark mode changes.
@@ -177,7 +187,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   const updatePrefs = useCallback((patch: Partial<StoredThemePrefs>) => {
     setPrefs(prev => {
       const next = { ...prev, ...patch };
-      storage.save(next);
+      storageRef.current.save(next);
       return next;
     });
   }, []);
@@ -186,6 +196,21 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   const setPreset = useCallback((presetId: string) => updatePrefs({ presetId }), [updatePrefs]);
   const setRadius = useCallback((radius: StoredThemePrefs['radius']) => updatePrefs({ radius }), [updatePrefs]);
   const setFont = useCallback((fontId: string) => updatePrefs({ fontId }), [updatePrefs]);
+
+  /** Called on logout — reverts to default theme and switches back to anonymous storage. */
+  const resetToDefaults = useCallback(() => {
+    storageRef.current = new LocalStoragePreferences();
+    storageRef.current.save(DEFAULT_PREFS);
+    setPrefs(DEFAULT_PREFS);
+  }, []);
+
+  /** Called on login — switches to per-user storage and restores saved prefs if any. */
+  const loadPrefsForUser = useCallback((userId: string) => {
+    const userStorage = new UserLocalStoragePreferences(userId);
+    storageRef.current = userStorage;
+    const saved = userStorage.load();
+    setPrefs(saved ?? DEFAULT_PREFS);
+  }, []);
 
   const value = useMemo<ThemeContextValue>(() => ({
     schoolName: NJIT_THEME.school_name,
@@ -203,7 +228,9 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     setRadius,
     fontId: prefs.fontId,
     setFont,
-  }), [prefs, resolvedThemeMode, setThemeMode, setPreset, setRadius, setFont]);
+    resetToDefaults,
+    loadPrefsForUser,
+  }), [prefs, resolvedThemeMode, setThemeMode, setPreset, setRadius, setFont, resetToDefaults, loadPrefsForUser]);
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 }

--- a/apps/web/src/contexts/ThemeContext.tsx
+++ b/apps/web/src/contexts/ThemeContext.tsx
@@ -154,6 +154,11 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   const resolvedThemeMode = resolveMode(prefs.mode, sysDark);
   const activePreset = findPreset(prefs.presetId);
 
+  // Set page title from school name.
+  useEffect(() => {
+    document.title = `${NJIT_THEME.school_name} Marketplace`;
+  }, []);
+
   // Apply dark class to <html>.
   useEffect(() => {
     document.documentElement.classList.toggle('dark', resolvedThemeMode === 'dark');

--- a/apps/web/src/features/form.tsx
+++ b/apps/web/src/features/form.tsx
@@ -96,18 +96,28 @@ export default function Form({
             return;
         }
 
-        if(listingDescription.trim().length > 2000 && !regex.test(listingDescription)) {
+        if (listingDescription.trim().length > 2000) {
             alert('Description cannot exceed 2000 characters.');
             setIsSubmitting(false);
             return;
         }
 
-        if(listingTitle.trim().length === 0) {
-            if (regex.test(listingTitle)) {
-                alert('Title cannot be empty.');
-                setIsSubmitting(false);
-                return;
-            }
+        if (regex.test(listingDescription)) {
+            alert('Description contains invalid content.');
+            setIsSubmitting(false);
+            return;
+        }
+
+        if (listingTitle.trim().length === 0) {
+            alert('Title cannot be empty.');
+            setIsSubmitting(false);
+            return;
+        }
+
+        if (regex.test(listingTitle)) {
+            alert('Title contains invalid content.');
+            setIsSubmitting(false);
+            return;
         }
 
         if(listingPrice < 0) {

--- a/apps/web/src/features/form.tsx
+++ b/apps/web/src/features/form.tsx
@@ -365,8 +365,11 @@ export default function Form({
 
                         <div className="grid grid-cols-2 gap-4">
                             <div className="col-span-2">
-                                <p className="mb-2 block text-[10px] font-semibold uppercase tracking-[0.08em] text-black/80">Listing Type</p>
-                                <div className="grid grid-cols-2 gap-1 rounded-lg border border-black/10 bg-white p-1">
+                                <p className="mb-2 block text-[10px] font-semibold uppercase tracking-[0.08em] text-black/80">
+                                    Listing Type
+                                    {editListing && <span className="ml-1.5 normal-case font-normal text-black/40">(cannot be changed after creation)</span>}
+                                </p>
+                                <div className={`grid grid-cols-2 gap-1 rounded-lg border border-black/10 bg-white p-1 ${editListing ? 'opacity-60' : ''}`}>
                                     <input
                                         type="radio"
                                         id="item"
@@ -374,11 +377,12 @@ export default function Form({
                                         value="item"
                                         checked={listingType === 'item'}
                                         onChange={() => setListingType('item')}
+                                        disabled={!!editListing}
                                         className="sr-only"
                                     />
                                     <label
                                         htmlFor="item"
-                                        className={`cursor-pointer rounded-md border px-3 py-2 text-center text-sm font-semibold transition ${listingType === 'item' ? 'border-[var(--color-primary-dark)] bg-[var(--color-primary)] text-white shadow-sm' : 'border-transparent bg-transparent text-black/75 hover:bg-black/5'}`}
+                                        className={`rounded-md border px-3 py-2 text-center text-sm font-semibold transition ${editListing ? 'cursor-default' : 'cursor-pointer'} ${listingType === 'item' ? 'border-[var(--color-primary-dark)] bg-[var(--color-primary)] text-white shadow-sm' : 'border-transparent bg-transparent text-black/75 hover:bg-black/5'}`}
                                     >
                                         Item
                                     </label>
@@ -390,11 +394,12 @@ export default function Form({
                                         value="service"
                                         checked={listingType === 'service'}
                                         onChange={() => setListingType('service')}
+                                        disabled={!!editListing}
                                         className="sr-only"
                                     />
                                     <label
                                         htmlFor="service"
-                                        className={`cursor-pointer rounded-md border px-3 py-2 text-center text-sm font-semibold transition ${listingType === 'service' ? 'border-[var(--color-primary-dark)] bg-[var(--color-primary)] text-white shadow-sm' : 'border-transparent bg-transparent text-black/75 hover:bg-black/5'}`}
+                                        className={`rounded-md border px-3 py-2 text-center text-sm font-semibold transition ${editListing ? 'cursor-default' : 'cursor-pointer'} ${listingType === 'service' ? 'border-[var(--color-primary-dark)] bg-[var(--color-primary)] text-white shadow-sm' : 'border-transparent bg-transparent text-black/75 hover:bg-black/5'}`}
                                     >
                                         Service
                                     </label>

--- a/apps/web/src/features/help-modal.tsx
+++ b/apps/web/src/features/help-modal.tsx
@@ -37,7 +37,7 @@ export function HelpModal({ isOpen, onClose }: HelpModalProps) {
                   <span>Go to Sign Up and create your account using your student email.</span>
                 </li>
                 <li className="flex items-start gap-2">
-                  <span className="text-[#9D4444] mt-1">2.</span>
+                  <span className="text-[var(--color-primary)] mt-1">2.</span>
                   <span>Sign in and complete your profile so other users can recognize you.</span>
                 </li>
               </ul>
@@ -51,11 +51,11 @@ export function HelpModal({ isOpen, onClose }: HelpModalProps) {
                   <span>Use the homepage search bar to find items or services.</span>
                 </li>
                 <li className="flex items-start gap-2">
-                  <span className="text-[#9D4444] mt-1">•</span>
+                  <span className="text-[var(--color-primary)] mt-1">•</span>
                   <span>Filter by listing type and category to narrow results.</span>
                 </li>
                 <li className="flex items-start gap-2">
-                  <span className="text-[#9D4444] mt-1">•</span>
+                  <span className="text-[var(--color-primary)] mt-1">•</span>
                   <span>Open a listing to view details, images, and price information.</span>
                 </li>
               </ul>
@@ -69,11 +69,11 @@ export function HelpModal({ isOpen, onClose }: HelpModalProps) {
                   <span>Open the post form from the sidebar.</span>
                 </li>
                 <li className="flex items-start gap-2">
-                  <span className="text-[#9D4444] mt-1">•</span>
+                  <span className="text-[var(--color-primary)] mt-1">•</span>
                   <span>Add a title, description, price, and category. Your draft listing is saved in My Listings.</span>
                 </li>
                 <li className="flex items-start gap-2">
-                  <span className="text-[#9D4444] mt-1">•</span>
+                  <span className="text-[var(--color-primary)] mt-1">•</span>
                   <span>Fill out all required fields, then publish your listing so other students can contact you.</span>
                 </li>
               </ul>
@@ -87,11 +87,11 @@ export function HelpModal({ isOpen, onClose }: HelpModalProps) {
                   <span>Open a listing and start a conversation.</span>
                 </li>
                 <li className="flex items-start gap-2">
-                  <span className="text-[#9D4444] mt-1">•</span>
+                  <span className="text-[var(--color-primary)] mt-1">•</span>
                   <span>Use the Messages page to continue the chat.</span>
                 </li>
                 <li className="flex items-start gap-2">
-                  <span className="text-[#9D4444] mt-1">•</span>
+                  <span className="text-[var(--color-primary)] mt-1">•</span>
                   <span>Keep communication clear by including pickup time and location details.</span>
                 </li>
               </ul>
@@ -105,7 +105,7 @@ export function HelpModal({ isOpen, onClose }: HelpModalProps) {
                   <span>Use Wishlist to save listings you want to revisit.</span>
                 </li>
                 <li className="flex items-start gap-2">
-                  <span className="text-[#9D4444] mt-1">•</span>
+                  <span className="text-[var(--color-primary)] mt-1">•</span>
                   <span>Go to My Listings to edit, unpublish, or remove your own posts.</span>
                 </li>
               </ul>

--- a/apps/web/src/features/page-header.tsx
+++ b/apps/web/src/features/page-header.tsx
@@ -46,11 +46,11 @@ export default function PageHeader({
             className="sticky top-0 z-50 w-full bg-[var(--color-primary)] border-b border-black/20 shadow-[0_4px_20px_rgba(0,0,0,0.4)]"
             style={{ fontFamily: "'Inter', sans-serif" }}
         >
-            <div className="relative flex items-center gap-4 px-5 py-2">
+            <div className="flex items-center gap-4 px-5 py-2">
 
                 {/* Left — logo + school name */}
-                <Link to="/" className="flex items-center gap-3 shrink-0 text-[var(--color-text-on-primary)] hover:opacity-90 transition-opacity">
-                    <div className="size-14 rounded-full flex items-center justify-center shadow-2xl overflow-hidden border-4" style={{background: '#99040B', borderColor: '#FFFFFF'}}>
+                <Link to="/" className="flex items-center gap-2 shrink-0 text-[var(--color-text-on-primary)] hover:opacity-90 transition-opacity">
+                    <div className="size-9 rounded-full flex items-center justify-center shadow-md overflow-hidden border-2" style={{background: '#99040B', borderColor: '#FFFFFF'}}>
                       <svg viewBox="0 0 40 40" className="w-full h-full">
                         {/* Shopping bag body */}
                         <path d="M 10 16 L 8 30 C 8 31 9 32 10 32 L 30 32 C 31 32 32 31 32 30 L 30 16 Z" fill="white" stroke="white" strokeWidth="0.5"/>
@@ -74,23 +74,21 @@ export default function PageHeader({
                     </span>
                 </Link>
 
-                {/* Center — search bar (homepage only) */}
+                {/* Center — search bar, always in-flow between logo and controls */}
                 {showSearch && (
-                    <div className="flex-1 max-w-lg mx-2 lg:absolute lg:left-1/2 lg:top-1/2 lg:w-full lg:-translate-x-1/2 lg:-translate-y-1/2 lg:px-4">
-                        <input
-                            id="search"
-                            name="search"
-                            type="text"
-                            placeholder="Search..."
-                            className="w-full rounded-lg bg-white/95 px-4 py-1.5 text-sm text-black placeholder:text-gray-400 outline-none focus:ring-2 focus:ring-white/50 transition-all"
-                            value={searchQuery}
-                            onChange={(e) => setSearchQuery?.(e.target.value)}
-                        />
-                    </div>
+                    <input
+                        id="search"
+                        name="search"
+                        type="text"
+                        placeholder="Search..."
+                        className="flex-1 min-w-0 rounded-lg bg-white/95 px-3 py-1.5 text-sm text-black placeholder:text-gray-400 outline-none focus:ring-2 focus:ring-white/50 transition-all"
+                        value={searchQuery}
+                        onChange={(e) => setSearchQuery?.(e.target.value)}
+                    />
                 )}
 
                 {/* Right — auth controls + notifications + buttons */}
-                <div className="flex items-center gap-6 ml-auto shrink-0">
+                <div className="flex items-center gap-3 sm:gap-6 ml-auto shrink-0">
                     {/* User profile and notifications section */}
                     <div className="flex items-center gap-4">
                         {isRegistering ? (
@@ -130,8 +128,8 @@ export default function PageHeader({
                         )}
                     </div>
 
-                    {/* About, Help, Contact buttons */}
-                    <div className="flex items-center gap-6 border-l border-white/20 pl-6">
+                    {/* About, Help, Contact buttons — hidden on small screens */}
+                    <div className="hidden md:flex items-center gap-6 border-l border-white/20 pl-6">
                         <button onClick={() => setShowAboutModal(true)} className="text-xs font-semibold uppercase tracking-wide text-white hover:opacity-80 transition-opacity">About</button>
                         <button onClick={() => setShowHelpModal(true)} className="text-xs font-semibold uppercase tracking-wide text-white hover:opacity-80 transition-opacity">Help</button>
                         <button onClick={() => setShowContactModal(true)} className="text-xs font-semibold uppercase tracking-wide text-white hover:opacity-80 transition-opacity">Contact</button>

--- a/apps/web/src/features/page-header.tsx
+++ b/apps/web/src/features/page-header.tsx
@@ -52,20 +52,20 @@ export default function PageHeader({
                 <Link to="/" className="flex items-center gap-3 shrink-0 text-[var(--color-text-on-primary)] hover:opacity-90 transition-opacity">
                     <div className="size-14 rounded-full flex items-center justify-center shadow-2xl overflow-hidden border-4" style={{background: '#99040B', borderColor: '#FFFFFF'}}>
                       <svg viewBox="0 0 40 40" className="w-full h-full">
-                        {/* Shopping bag body - white */}
+                        {/* Shopping bag body */}
                         <path d="M 10 16 L 8 30 C 8 31 9 32 10 32 L 30 32 C 31 32 32 31 32 30 L 30 16 Z" fill="white" stroke="white" strokeWidth="0.5"/>
 
-                        {/* Bag handle - white */}
+                        {/* Bag handle */}
                         <path d="M 12 14 C 12 10 14.5 8 20 8 C 25.5 8 28 10 28 14" fill="none" stroke="white" strokeWidth="3" strokeLinecap="round"/>
 
-                        {/* Eyes - dots */}
-                        <circle cx="15" cy="20" r="1.5" fill="#780006"/>
-                        <circle cx="25" cy="20" r="1.5" fill="#780006"/>
+                        {/* Eyes */}
+                        <circle cx="15.5" cy="22" r="1.6" fill="#780006"/>
+                        <circle cx="24.5" cy="22" r="1.6" fill="#780006"/>
 
                         {/* Smile */}
-                        <path d="M 14 24 Q 20 27 26 24" fill="none" stroke="#780006" strokeWidth="2" strokeLinecap="round"/>
+                        <path d="M 14.5 25.5 Q 20 28.5 25.5 25.5" fill="none" stroke="#780006" strokeWidth="2" strokeLinecap="round"/>
 
-                        {/* Bottom stripe - white */}
+                        {/* Bottom stripe */}
                         <path d="M 10 28 L 8 30 C 8 31 9 32 10 32 L 30 32 C 31 32 32 31 32 30 L 30 28 Z" fill="white"/>
                       </svg>
                     </div>

--- a/apps/web/src/features/theme-customizer/PresetGrid.tsx
+++ b/apps/web/src/features/theme-customizer/PresetGrid.tsx
@@ -3,61 +3,43 @@ import { useTheme } from '../../contexts/ThemeContext';
 export default function PresetGrid() {
   const { presets, activePresetId, setPreset, resolvedThemeMode } = useTheme();
 
-  const school = presets.filter(p => p.category === 'school');
-  const generic = presets.filter(p => p.category === 'generic');
-
   return (
-    <div className="space-y-3">
-      <PresetSection label="NJIT" presets={school} activeId={activePresetId} mode={resolvedThemeMode} onSelect={setPreset} />
-      <PresetSection label="Generic" presets={generic} activeId={activePresetId} mode={resolvedThemeMode} onSelect={setPreset} />
-    </div>
-  );
-}
-
-function PresetSection({
-  label,
-  presets,
-  activeId,
-  mode,
-  onSelect,
-}: {
-  label: string;
-  presets: ReturnType<typeof useTheme>['presets'];
-  activeId: string;
-  mode: 'light' | 'dark';
-  onSelect: (id: string) => void;
-}) {
-  return (
-    <div>
-      <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">{label}</p>
-      <div className="grid grid-cols-2 gap-2">
-        {presets.map(preset => {
-          const colors = mode === 'dark' ? preset.dark : preset.light;
-          const isActive = preset.id === activeId;
-          return (
-            <button
-              key={preset.id}
-              type="button"
-              onClick={() => onSelect(preset.id)}
-              className={[
-                'flex items-center gap-2.5 rounded-lg border px-2.5 py-2 text-left transition-all',
-                isActive
-                  ? 'border-[var(--color-primary)] bg-[var(--color-primary)]/8 ring-1 ring-[var(--color-primary)]'
-                  : 'border-[var(--color-border)] bg-[var(--color-surface)] hover:border-[var(--color-primary)]/50',
-              ].join(' ')}
-            >
-              {/* Color swatch */}
+    <div className="flex flex-col gap-2">
+      {presets.map(preset => {
+        const colors = resolvedThemeMode === 'dark' ? preset.dark : preset.light;
+        const isActive = preset.id === activePresetId;
+        return (
+          <button
+            key={preset.id}
+            type="button"
+            onClick={() => setPreset(preset.id)}
+            className={[
+              'flex items-center gap-3 rounded-xl border px-3 py-2.5 text-left transition-all',
+              isActive
+                ? 'border-[var(--color-primary)] bg-[var(--color-primary)]/8 ring-1 ring-[var(--color-primary)]'
+                : 'border-[var(--color-border)] bg-[var(--color-surface)] hover:border-[var(--color-primary)]/40',
+            ].join(' ')}
+          >
+            {/* Swatch cluster */}
+            <span className="relative h-7 w-7 shrink-0">
               <span
-                className="h-6 w-6 shrink-0 rounded-full shadow-sm ring-1 ring-black/10"
+                className="absolute inset-0 rounded-full shadow-sm ring-1 ring-black/10"
                 style={{ backgroundColor: colors.primary }}
               />
-              <span className="truncate text-xs font-medium text-[var(--color-text-on-primary-surface,#111)]" style={{ color: 'inherit' }}>
-                {preset.name}
+              <span
+                className="absolute bottom-0 right-0 h-3.5 w-3.5 rounded-full ring-1 ring-black/10"
+                style={{ backgroundColor: colors.background }}
+              />
+            </span>
+            <span className="text-sm font-medium text-[var(--color-text)]">{preset.name}</span>
+            {isActive && (
+              <span className="ml-auto text-[10px] font-semibold uppercase tracking-wide text-[var(--color-primary)]">
+                Active
               </span>
-            </button>
-          );
-        })}
-      </div>
+            )}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/apps/web/src/features/theme-customizer/RadiusPicker.tsx
+++ b/apps/web/src/features/theme-customizer/RadiusPicker.tsx
@@ -9,7 +9,7 @@ export default function RadiusPicker() {
       {RADIUS_OPTIONS.map(option => {
         const isActive = radiusId === option.id;
         /** Preview radius: cap at 12px so the visual box stays readable. */
-        const previewRadius = option.id === 'pill' ? '12px' : option.vars['--radius'];
+        const previewRadius = option.vars['--radius'];
         return (
           <button
             key={option.id}

--- a/apps/web/src/features/theme-customizer/index.tsx
+++ b/apps/web/src/features/theme-customizer/index.tsx
@@ -1,5 +1,6 @@
-import { X } from 'lucide-react';
-import ThemeModeToggle from '../theme-mode-toggle';
+import { Monitor, Sun, Moon, X, Lock } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { useTheme, type ThemeModePreference } from '../../contexts/ThemeContext';
 import PresetGrid from './PresetGrid';
 import RadiusPicker from './RadiusPicker';
 import FontPicker from './FontPicker';
@@ -7,63 +8,117 @@ import FontPicker from './FontPicker';
 type ThemeCustomizerProps = {
   open: boolean;
   onClose: () => void;
+  isLoggedIn: boolean;
 };
 
-export default function ThemeCustomizer({ open, onClose }: ThemeCustomizerProps) {
+const MODES: { value: ThemeModePreference; label: string; Icon: typeof Monitor }[] = [
+  { value: 'light',  label: 'Light',  Icon: Sun     },
+  { value: 'dark',   label: 'Dark',   Icon: Moon    },
+  { value: 'system', label: 'System', Icon: Monitor },
+];
+
+export default function ThemeCustomizer({ open, onClose, isLoggedIn }: ThemeCustomizerProps) {
+  const { themeModePreference, setThemeMode } = useTheme();
+
   return (
     <>
-      {/* Backdrop */}
       {open && (
         <div
-          className="fixed inset-0 z-40 bg-black/30"
+          className="fixed inset-0 z-40 bg-black/40 backdrop-blur-sm"
           onClick={onClose}
           aria-hidden="true"
         />
       )}
 
-      {/* Panel */}
       <div
         className={[
-          'fixed left-0 top-0 z-50 flex h-full w-72 flex-col bg-[var(--color-background)] shadow-2xl transition-transform duration-300',
+          'fixed left-0 top-0 z-50 flex h-full w-80 flex-col bg-[var(--color-background)] shadow-2xl transition-transform duration-300',
           open ? 'translate-x-0' : '-translate-x-full',
         ].join(' ')}
-        aria-label="Appearance settings"
         role="dialog"
         aria-modal="true"
+        aria-label="Appearance settings"
       >
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-[var(--color-border)] px-4 py-3">
-          <h2 className="text-sm font-semibold">Appearance</h2>
+        <div className="flex items-center justify-between px-5 py-4 border-b border-[var(--color-border)]">
+          <div>
+            <h2 className="text-base font-semibold text-[var(--color-text)]">Appearance</h2>
+            <p className="text-xs text-[var(--color-text-muted)] mt-0.5">
+              {isLoggedIn ? 'Customize how the app looks' : 'Log in to unlock customization'}
+            </p>
+          </div>
           <button
             type="button"
             onClick={onClose}
-            className="rounded-md p-1 text-[var(--color-text-muted)] hover:bg-[var(--color-surface)] hover:text-[var(--color-primary)] transition-colors"
-            aria-label="Close appearance settings"
+            className="rounded-lg p-1.5 text-[var(--color-text-muted)] hover:bg-[var(--color-surface)] hover:text-[var(--color-text)] transition-colors"
+            aria-label="Close"
           >
             <X size={16} />
           </button>
         </div>
 
-        {/* Scrollable content */}
-        <div className="flex-1 space-y-5 overflow-y-auto px-4 py-4">
-          <Section label="Theme">
-            <PresetGrid />
-          </Section>
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto px-5 py-5 space-y-6">
 
+          {/* Mode — always available */}
           <Section label="Mode">
-            {/* ThemeModeToggle uses --color-primary colors so wrap in primary bg */}
-            <div className="inline-flex rounded-xl bg-[var(--color-primary)] p-0.5">
-              <ThemeModeToggle />
+            <div className="grid grid-cols-3 gap-2">
+              {MODES.map(({ value, label, Icon }) => {
+                const active = themeModePreference === value;
+                return (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => setThemeMode(value)}
+                    className={[
+                      'flex flex-col items-center gap-2 rounded-xl border py-3 transition-all',
+                      active
+                        ? 'border-[var(--color-primary)] bg-[var(--color-primary)]/8 text-[var(--color-primary)] ring-1 ring-[var(--color-primary)]'
+                        : 'border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text-muted)] hover:border-[var(--color-primary)]/40 hover:text-[var(--color-text)]',
+                    ].join(' ')}
+                  >
+                    <Icon size={17} />
+                    <span className="text-xs font-medium">{label}</span>
+                  </button>
+                );
+              })}
             </div>
           </Section>
 
-          <Section label="Corners">
-            <RadiusPicker />
-          </Section>
+          {/* Locked sections — require login */}
+          {isLoggedIn ? (
+            <>
+              <Section label="Theme">
+                <PresetGrid />
+              </Section>
 
-          <Section label="Font">
-            <FontPicker />
-          </Section>
+              <Section label="Corners">
+                <RadiusPicker />
+              </Section>
+
+              <Section label="Font">
+                <FontPicker />
+              </Section>
+            </>
+          ) : (
+            <div className="rounded-xl border border-dashed border-[var(--color-border)] px-4 py-6 flex flex-col items-center gap-3 text-center">
+              <span className="flex h-10 w-10 items-center justify-center rounded-full bg-[var(--color-surface)]">
+                <Lock size={18} className="text-[var(--color-text-muted)]" />
+              </span>
+              <div>
+                <p className="text-sm font-medium text-[var(--color-text)]">Theme customization locked</p>
+                <p className="mt-1 text-xs text-[var(--color-text-muted)]">Log in to change themes, corners, and fonts</p>
+              </div>
+              <Link
+                to="/login"
+                onClick={onClose}
+                className="mt-1 rounded-lg bg-[var(--color-primary)] px-4 py-2 text-xs font-semibold text-[var(--color-text-on-primary)] hover:opacity-90 transition-opacity"
+              >
+                Log in
+              </Link>
+            </div>
+          )}
+
         </div>
       </div>
     </>
@@ -73,7 +128,7 @@ export default function ThemeCustomizer({ open, onClose }: ThemeCustomizerProps)
 function Section({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div>
-      <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
+      <p className="mb-2.5 text-xs font-semibold uppercase tracking-widest text-[var(--color-text-muted)]">
         {label}
       </p>
       {children}

--- a/apps/web/src/layouts/sidebar-layout.tsx
+++ b/apps/web/src/layouts/sidebar-layout.tsx
@@ -8,6 +8,7 @@ import { getSessionFromTokens, getNotifications, subscribeToNotifications, markA
 import { useProfile } from "../hooks/useProfile";
 import type { SessionUser } from "../features/types";
 import { useNavigate } from 'react-router-dom';
+import { useTheme } from '../contexts/ThemeContext';
 
 export default function SidebarLayout() {
     const [searchQuery, setSearchQuery] = useState('');
@@ -31,6 +32,7 @@ export default function SidebarLayout() {
     // Profile is fetched via the cache — shared with profile.tsx and my-listings.tsx.
     const { data: profile } = useProfile(user?.id);
     const navigate = useNavigate();
+    const { resetToDefaults, loadPrefsForUser } = useTheme();
 
     const clearStoredTokens = () => {
         localStorage.removeItem("access_token");
@@ -41,6 +43,7 @@ export default function SidebarLayout() {
         clearStoredTokens();
         setIsLoggedIn(false);
         setUser(null);
+        resetToDefaults();
         navigate("/login", { replace: true });
     };
 
@@ -93,6 +96,7 @@ export default function SidebarLayout() {
                 }
 
                 setUser(user);
+                loadPrefsForUser(user.id);
                 const notifs = await getNotifications(user.id);
                 setNotifications(notifs);
                 setIsLoggedIn(true);
@@ -104,7 +108,7 @@ export default function SidebarLayout() {
         };
 
         void checkUserSession();
-    }, [location.pathname, profileRefreshKey]);
+    }, [location.pathname, profileRefreshKey, loadPrefsForUser]);
 
     // Subscribe to realtime notifications when user logs in.
     useEffect(() => {
@@ -115,6 +119,7 @@ export default function SidebarLayout() {
         });
 
         return unsubscribe;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [user?.id]);
 
     return (
@@ -171,6 +176,7 @@ export default function SidebarLayout() {
             <ThemeCustomizer
                 open={showCustomizer}
                 onClose={() => setShowCustomizer(false)}
+                isLoggedIn={!!user}
             />
         </div>
     );

--- a/apps/web/src/lib/theme-storage.ts
+++ b/apps/web/src/lib/theme-storage.ts
@@ -7,7 +7,7 @@
 export interface StoredThemePrefs {
   presetId: string;
   mode: 'system' | 'light' | 'dark';
-  radius: 'sharp' | 'default' | 'rounded' | 'pill';
+  radius: 'sharp' | 'default' | 'rounded';
   fontId: string;
 }
 
@@ -19,6 +19,7 @@ export interface PreferencesStorage {
 const PREFS_KEY = 'campus-marketplace-theme-prefs';
 /** Legacy key written by the old ThemeContext — only stored the dark mode preference. */
 const LEGACY_MODE_KEY = 'campus-marketplace-theme-mode';
+const USER_PREFS_KEY_PREFIX = 'campus-marketplace-theme-prefs-user';
 
 export class LocalStoragePreferences implements PreferencesStorage {
   load(): StoredThemePrefs | null {
@@ -48,6 +49,33 @@ export class LocalStoragePreferences implements PreferencesStorage {
   save(prefs: StoredThemePrefs): void {
     try {
       localStorage.setItem(PREFS_KEY, JSON.stringify(prefs));
+    } catch {
+      // Ignore storage errors
+    }
+  }
+}
+
+/** Per-user prefs stored under a user-specific key so each account has its own theme. */
+export class UserLocalStoragePreferences implements PreferencesStorage {
+  private readonly key: string;
+
+  constructor(userId: string) {
+    this.key = `${USER_PREFS_KEY_PREFIX}-${userId}`;
+  }
+
+  load(): StoredThemePrefs | null {
+    try {
+      const raw = localStorage.getItem(this.key);
+      if (raw) return JSON.parse(raw) as StoredThemePrefs;
+    } catch {
+      // Ignore storage errors
+    }
+    return null;
+  }
+
+  save(prefs: StoredThemePrefs): void {
+    try {
+      localStorage.setItem(this.key, JSON.stringify(prefs));
     } catch {
       // Ignore storage errors
     }

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -199,8 +199,12 @@ const displayName = profile?.display_name ?? user?.email ?? "there";
                 style={{ backgroundColor: "var(--color-primary)" }}
             >
                 <div>
-                    <p className="text-2xl font-bold">Welcome back, {displayName}!</p>
-                    <p className="mt-1 text-sm opacity-80">Discover great deals from fellow NJIT students</p>
+                    <p className="text-2xl font-bold">
+                        {user ? `Welcome back, ${displayName}!` : 'Find great deals at NJIT'}
+                    </p>
+                    <p className="mt-1 text-sm opacity-80">
+                        {user ? 'Discover great deals from fellow NJIT students' : 'Browse listings from students and businesses on campus'}
+                    </p>
                 </div>
                 {/* Stat tiles stay white-on-red — intentional design contrast */}
                 <div className="flex shrink-0 gap-3">

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -56,7 +56,7 @@ function useCountUp(target: number | undefined, duration = 900): number {
 export default function Index() {
     const location = useLocation();
     const navigate = useNavigate();
-    const { searchQuery, listingsRefreshKey, user } = useOutletContext<OutletContext>();
+    const { searchQuery, user } = useOutletContext<OutletContext>();
 
     const [category, setCategory] = useState<string>("");
     const [listingType, setListingType] = useState<"" | "item" | "service">("");
@@ -122,7 +122,7 @@ export default function Index() {
         // Start exit animation at 2300ms so the slide-out completes at ~2600ms total.
         const timer = window.setTimeout(dismissToast, 2300);
         return () => window.clearTimeout(timer);
-    }, [wishlistToast]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [wishlistToast]);
 
     useEffect(() => {
         const target = loadMoreRef.current;
@@ -140,11 +140,7 @@ export default function Index() {
         return () => observer.disconnect();
     }, [isFetchingNextPage, hasNextPage, fetchNextPage]);
 
-    // listingsRefreshKey increments when the user posts a new listing.
-    // TanStack Query handles the actual refetch via cache invalidation in the form component.
-    useEffect(() => {}, [listingsRefreshKey]);
-
-    const displayName = profile?.display_name ?? user?.email ?? "there";
+const displayName = profile?.display_name ?? user?.email ?? "there";
 
     async function handleWishlistToggle(e: React.MouseEvent, listing: ListingWithDetails) {
         e.preventDefault();

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -1,9 +1,9 @@
 import { getListingImageUrl } from "@campus-marketplace/backend";
 import type { Category } from "@campus-marketplace/backend";
 import type { ListingWithDetails } from "@campus-marketplace/backend";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type ComponentType } from "react";
 import { Link, useLocation, useNavigate, useOutletContext } from "react-router-dom";
-import { Monitor, Shirt, Sofa, BookOpen, Gift, Dumbbell, Zap, Bookmark, MoreHorizontal, Bike, BriefcaseBusiness, BookText } from "lucide-react";
+import { Monitor, Shirt, Sofa, BookOpen, Gift, Dumbbell, Zap, Bookmark, BookText, Bike, Home, UtensilsCrossed, Gamepad2, Music, Package } from "lucide-react";
 import { NoImagePlaceholder } from "../components/NoImagePlaceholder";
 import { useCategories } from "../hooks/useCategories.ts";
 import { useSearchListings } from "../hooks/useListings";
@@ -14,39 +14,42 @@ import type { SessionUser } from "../features/types";
 
 type OutletContext = {
     searchQuery: string;
-    listingsRefreshKey: number;
     user: SessionUser | null;
 };
 
 const PAGE_SIZE = 12;
 
-const CATEGORY_DISPLAY = {
-    Electronics: { label: "Electronics", icon: Monitor, bgClass: "bg-blue-500" },
-    Clothing: { label: "Clothing", icon: Shirt, bgClass: "bg-violet-500" },
-    Furniture: { label: "Furniture", icon: Sofa, bgClass: "bg-orange-500" },
-    "School Supplies": { label: "School Supplies", icon: BookOpen, bgClass: "bg-emerald-500" },
-    "Free Stuff": { label: "Free Stuff", icon: Gift, bgClass: "bg-pink-500" },
-    "Sports & Fitness": { label: "Sports", icon: Dumbbell, bgClass: "bg-[var(--color-primary)]" },
-    Services: { label: "Services", icon: BriefcaseBusiness, bgClass: "bg-amber-500" },
-    Textbooks: { label: "Textbooks", icon: BookText, bgClass: "bg-cyan-600" },
-    Transportation: { label: "Transportation", icon: Bike, bgClass: "bg-indigo-500" },
-    Other: { label: "Other", icon: MoreHorizontal, bgClass: "bg-slate-500" },
-} as const;
+const CATEGORY_DISPLAY: Record<string, { label: string; icon: ComponentType<{ size?: number; color?: string }>; bgClass: string }> = {
+    Electronics:      { label: "Electronics",     icon: Monitor,         bgClass: "bg-blue-500"    },
+    Textbooks:        { label: "Textbooks",        icon: BookText,        bgClass: "bg-amber-500"   },
+    Clothing:         { label: "Clothing",         icon: Shirt,           bgClass: "bg-violet-500"  },
+    Furniture:        { label: "Furniture",        icon: Sofa,            bgClass: "bg-orange-500"  },
+    "School Supplies":{ label: "School Supplies",  icon: BookOpen,        bgClass: "bg-emerald-500" },
+    "Sports & Fitness":{ label: "Sports & Fitness",icon: Dumbbell,        bgClass: "bg-red-500"     },
+    "Free Stuff":     { label: "Free Stuff",       icon: Gift,            bgClass: "bg-pink-500"    },
+    Transportation:   { label: "Transportation",   icon: Bike,            bgClass: "bg-cyan-500"    },
+    Housing:          { label: "Housing",          icon: Home,            bgClass: "bg-teal-500"    },
+    "Food & Drinks":  { label: "Food & Drinks",    icon: UtensilsCrossed, bgClass: "bg-lime-500"    },
+    Gaming:           { label: "Gaming",           icon: Gamepad2,        bgClass: "bg-purple-500"  },
+    Music:            { label: "Music",            icon: Music,           bgClass: "bg-fuchsia-500" },
+    Other:            { label: "Other",            icon: Package,         bgClass: "bg-slate-500"   },
+};
 
 const CATEGORY_ORDER = [
     "Electronics",
+    "Textbooks",
     "Clothing",
     "Furniture",
     "School Supplies",
-    "Free Stuff",
     "Sports & Fitness",
-    "Services",
-    "Textbooks",
+    "Free Stuff",
     "Transportation",
+    "Housing",
+    "Food & Drinks",
+    "Gaming",
+    "Music",
     "Other",
-] as const;
-
-const DEFAULT_VISIBLE_CATEGORY_COUNT = 6;
+];
 
 const shimmerStyle: React.CSSProperties = {
     background: "linear-gradient(90deg, var(--color-background-alt) 25%, var(--color-border) 50%, var(--color-background-alt) 75%)",
@@ -82,7 +85,6 @@ export default function Index() {
     const [category, setCategory] = useState<string>("");
     const [listingType, setListingType] = useState<"" | "item" | "service">("");
     const [priceRange, setPriceRange] = useState<"" | "u25" | "25-100" | "100-500" | "o500">("");
-    const [showAllCategories, setShowAllCategories] = useState(false);
     const [wishlistToast, setWishlistToast] = useState<string | null>(null);
     const [toastExiting, setToastExiting] = useState(false);
     const loadMoreRef = useRef<HTMLDivElement | null>(null);
@@ -120,13 +122,6 @@ export default function Index() {
             }];
         });
     }, [categories]);
-
-    const visibleCategoryButtons = useMemo(() => {
-        if (showAllCategories) return categoryButtons;
-        return categoryButtons.slice(0, DEFAULT_VISIBLE_CATEGORY_COUNT);
-    }, [categoryButtons, showAllCategories]);
-
-    const canExpandCategories = categoryButtons.length > DEFAULT_VISIBLE_CATEGORY_COUNT;
 
     const filters = useMemo(() => {
         const priceFilters =
@@ -242,67 +237,54 @@ const displayName = profile?.display_name ?? user?.email ?? "there";
 
             {/* ── Welcome Banner ── */}
             <div
-                className="flex flex-col gap-4 rounded-2xl p-5 text-white md:flex-row md:items-center md:justify-between"
-                style={{ backgroundColor: "var(--color-primary)" }}
+                className="rounded-2xl p-5 text-white shadow-[0_6px_28px_rgba(0,0,0,0.22)]"
+                style={{ background: "linear-gradient(150deg, var(--color-primary-dark) 0%, var(--color-primary) 100%)" }}
             >
-                <div>
-                    <p className="text-2xl font-bold">
-                        {user ? `Welcome back, ${displayName}!` : 'Find great deals at NJIT'}
-                    </p>
-                    <p className="mt-1 text-sm opacity-80">
-                        {user ? 'Discover great deals from fellow NJIT students' : 'Browse listings from students and businesses on campus'}
-                    </p>
-                </div>
-                {/* Stat tiles stay white-on-red — intentional design contrast */}
-                <div className="flex shrink-0 gap-3">
+                <p className="text-xl sm:text-2xl font-bold">
+                    {user ? `Welcome back, ${displayName}!` : 'Find great deals at NJIT'}
+                </p>
+                <p className="mt-1 text-sm opacity-80">
+                    {user ? 'Discover great deals from fellow NJIT students' : 'Browse listings from students and businesses on campus'}
+                </p>
+                <div className="mt-4 grid grid-cols-3 gap-3">
                     {([
                         { value: statsLoading ? "—" : activeListingsCount, label: "Active Listings" },
                         { value: statsLoading ? "—" : activeUsersCount, label: "Active Users" },
                         { value: statsLoading ? "—" : newTodayCount, label: "New Today" },
                     ] as const).map((tile) => (
-                        <div key={tile.label} className="flex min-w-[80px] flex-col items-center rounded-xl bg-white px-3 py-2 text-black">
-                            <span className="text-lg font-bold leading-none">{String(tile.value)}</span>
-                            <span className="mt-0.5 text-center text-xs text-black/60">{tile.label}</span>
+                        <div key={tile.label} className="flex flex-col items-center rounded-xl bg-white/15 border border-white/20 px-3 py-3">
+                            <span className="text-xl font-bold leading-none text-white">{String(tile.value)}</span>
+                            <span className="mt-1 text-center text-xs text-white/70">{tile.label}</span>
                         </div>
                     ))}
                 </div>
             </div>
 
             {/* ── Browse by Category + Filters (merged) ── */}
-            <div className="rounded-2xl p-5 shadow-sm" style={{ backgroundColor: "var(--color-surface)" }}>
+            <div className="rounded-2xl p-3 sm:p-5 shadow-sm" style={{ backgroundColor: "var(--color-surface)" }}>
                 {/* Category header */}
-                <div className="mb-3 flex items-center justify-between gap-4">
+                <div className="mb-3">
                     <p className="text-lg font-bold" style={{ color: "var(--color-text)" }}>Browse by Category</p>
-                    {canExpandCategories && (
-                        <button
-                            type="button"
-                            className="text-sm font-medium transition hover:opacity-80"
-                            style={{ color: "var(--color-primary)" }}
-                            onClick={() => setShowAllCategories((current) => !current)}
-                        >
-                            {showAllCategories ? "Show less" : "See all"}
-                        </button>
-                    )}
                 </div>
 
-                {/* Category tiles */}
-                <div className="grid px-1 py-3" style={{ gridTemplateColumns: `repeat(${Math.max(visibleCategoryButtons.length, 1)}, minmax(0, 1fr))`, gap: "1rem" }}>
-                    {visibleCategoryButtons.map(({ label, id, icon: Icon, bgClass }) => {
+                {/* Category tiles — horizontal scroll on mobile, single-row grid on lg+ */}
+                <div className="flex gap-3 overflow-x-auto py-2 lg:grid lg:grid-cols-[repeat(13,minmax(0,1fr))] lg:gap-2 lg:overflow-visible">
+                    {categoryButtons.map(({ label, id, icon: Icon, bgClass }) => {
                         const isActive = category === id;
                         return (
                             <button
                                 key={id}
                                 type="button"
                                 aria-pressed={isActive}
-                                className="flex flex-col items-center gap-2"
+                                className="flex shrink-0 w-16 flex-col items-center lg:w-full"
                                 onClick={() => setCategory(isActive ? "" : id)}
                             >
                                 <div
-                                    className={`flex h-16 w-16 items-center justify-center rounded-2xl ${bgClass}${isActive ? " ring-2 ring-[var(--color-primary)] ring-offset-2 ring-offset-[var(--color-surface)]" : ""}`}
+                                    className={`flex h-11 w-11 items-center justify-center rounded-xl ${bgClass}${isActive ? " ring-2 ring-[var(--color-primary)] ring-offset-2 ring-offset-[var(--color-surface)]" : ""}`}
                                 >
-                                    <Icon size={32} color="white" />
+                                    <Icon size={20} color="white" />
                                 </div>
-                                <span className="text-center text-sm font-medium leading-tight" style={{ color: "var(--color-text)" }}>{label}</span>
+                                <span className="mt-1 w-16 text-center text-xs font-medium leading-tight line-clamp-2 lg:w-full" style={{ color: "var(--color-text)" }}>{label}</span>
                             </button>
                         );
                     })}
@@ -357,7 +339,7 @@ const displayName = profile?.display_name ?? user?.email ?? "there";
                         type="button"
                         className="rounded-lg border px-3 py-2 text-sm font-medium transition hover:bg-[var(--color-background)] lg:ml-auto"
                         style={{ borderColor: "var(--color-border)", color: "var(--color-text)" }}
-                        onClick={() => { setListingType(""); setCategory(""); setPriceRange(""); setShowAllCategories(false); }}
+                        onClick={() => { setListingType(""); setCategory(""); setPriceRange(""); }}
                     >
                         Clear Filters
                     </button>
@@ -438,7 +420,7 @@ const displayName = profile?.display_name ?? user?.email ?? "there";
                                                     <button
                                                         type="button"
                                                         onClick={(e) => void handleWishlistToggle(e, listing)}
-                                                        className={`flex items-center gap-1.5 rounded-full px-2.5 py-2 shadow-md transition ${saved ? "bg-[var(--color-primary)] text-white" : "hover:bg-[var(--color-primary)] hover:text-white"}`}
+                                                        className={`flex items-center rounded-full px-2.5 py-2 shadow-md transition ${saved ? "bg-[var(--color-primary)] text-white" : "hover:bg-[var(--color-primary)] hover:text-white"}`}
                                                         style={saved ? {} : { backgroundColor: "var(--color-surface)", color: "var(--color-text-muted)" }}
                                                         aria-label={saved ? "Remove from wishlist" : "Add to wishlist"}
                                                     >
@@ -447,7 +429,7 @@ const displayName = profile?.display_name ?? user?.email ?? "there";
                                                             className="shrink-0"
                                                             fill={saved ? "currentColor" : "none"}
                                                         />
-                                                        <span className="max-w-0 overflow-hidden whitespace-nowrap text-xs font-medium transition-all duration-200 group-hover:max-w-[96px]">
+                                                        <span className="max-w-0 overflow-hidden whitespace-nowrap text-xs font-medium transition-all duration-200 group-hover:max-w-[96px] group-hover:pl-1.5">
                                                             {saved ? "Saved" : "Add to wishlist"}
                                                         </span>
                                                     </button>

--- a/apps/web/src/pages/listing.tsx
+++ b/apps/web/src/pages/listing.tsx
@@ -112,6 +112,17 @@ export default function Listing() {
             missing.push("images");
         }
 
+        if (listingData.type === "item") {
+            if (!listingData.item_details?.condition) missing.push("item_condition");
+            if (!listingData.item_details?.quantity || listingData.item_details.quantity < 1) missing.push("item_quantity");
+        }
+
+        if (listingData.type === "service") {
+            if (!listingData.service_details?.duration_minutes || listingData.service_details.duration_minutes <= 0) {
+                missing.push("service_duration_minutes");
+            }
+        }
+
         return missing;
     };
 

--- a/apps/web/src/pages/listing.tsx
+++ b/apps/web/src/pages/listing.tsx
@@ -31,7 +31,7 @@ export default function Listing() {
     // Show unavailable message when listing is inactive and viewer is not the owner.
     const unavailableMessage =
         listingData && listingData.status !== "active" && (!user || user.id !== listingData.user_id)
-            ? "This listing is no longer avaible"
+            ? "This listing is no longer available"
             : null;
 
     const formatDateTime = (value?: string | null) => {
@@ -154,6 +154,7 @@ export default function Listing() {
                 }
             } catch (error) {
                 console.error("Error publishing listing:", error);
+                await showAlert("Error", "Failed to publish listing. Please try again.");
             }
         }
         else if (listingData.status === "active") {
@@ -164,6 +165,7 @@ export default function Listing() {
                 await refetchListing();
             } catch (error) {
                 console.error("Error unpublishing listing:", error);
+                await showAlert("Error", "Failed to unpublish listing. Please try again.");
             }
         }
         setPublishLoading(false);

--- a/apps/web/src/pages/messages.tsx
+++ b/apps/web/src/pages/messages.tsx
@@ -26,6 +26,7 @@ export default function Messages() {
     );
     const [messages, setMessages] = useState<Message[]>([]);
     const [messageInput, setMessageInput] = useState("");
+    const [isSending, setIsSending] = useState(false);
     const [searchFilter, setSearchFilter] = useState("");
     const [chatLoading, setChatLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -164,10 +165,11 @@ export default function Messages() {
 
     // --- send a message ---
     async function handleSend() {
-        if (!activeConversationId || !user || !messageInput.trim()) return;
+        if (!activeConversationId || !user || !messageInput.trim() || isSending) return;
 
         const content = messageInput.trim();
         setMessageInput("");
+        setIsSending(true);
 
         try {
             const sent = await sendMessage(activeConversationId, user.id, content);
@@ -182,6 +184,8 @@ export default function Messages() {
         } catch (err) {
             console.error("Failed to send message:", err);
             setError("Failed to send message. Please try again.");
+        } finally {
+            setIsSending(false);
         }
     }
 
@@ -282,6 +286,7 @@ export default function Messages() {
                             messageInput={messageInput}
                             onInputChange={setMessageInput}
                             onSend={handleSend}
+                            isSending={isSending}
                             loading={chatLoading}
                             onBack={() => setMobileView("list")}
                             listingId={activeConvo.listing_id}

--- a/apps/web/src/pages/profile.tsx
+++ b/apps/web/src/pages/profile.tsx
@@ -189,6 +189,8 @@ export default function Profile() {
             });
         } catch (error) {
             console.error("Failed to save profile:", error);
+            await showAlert("Error", "Failed to save profile. Please try again.");
+            return;
         }
 
         setIsEditing(false);

--- a/supabase/migrations/20260421120000_add_missing_indexes.sql
+++ b/supabase/migrations/20260421120000_add_missing_indexes.sql
@@ -1,0 +1,9 @@
+-- Add indexes for common sort/filter patterns that currently do full table scans.
+
+-- "Newest first" sorts on the listings browse/search pages.
+create index if not exists listings_created_at_idx
+  on public.listings (created_at desc);
+
+-- Hierarchical category lookups (parent → children).
+create index if not exists categories_parent_id_idx
+  on public.categories (parent_id);

--- a/supabase/migrations/20260421130000_add_more_categories.sql
+++ b/supabase/migrations/20260421130000_add_more_categories.sql
@@ -1,0 +1,6 @@
+insert into public.categories (name, description) values
+  ('Housing',       'Sublease listings, roommate searches, and housing accessories'),
+  ('Food & Drinks', 'Meal plans, snacks, beverages, and kitchen items'),
+  ('Gaming',        'Video games, consoles, controllers, and accessories'),
+  ('Music',         'Instruments, equipment, sheet music, and audio gear')
+on conflict do nothing;


### PR DESCRIPTION
## Summary                                                                                                                                        
                                                            
  Pre-launch polish and bug fix pass across the frontend. Covers theming,                                                                           
  the homepage, categories, listing forms, and the page header.
                                                                                                                                                    
  ---                                                       

  ### Theme — per-user persistence

  - **Theme resets on logout** and restores to the user's saved preferences on
    login. Previously the theme stayed as-is after signing out.
  - Added `UserLocalStoragePreferences` class that keys preferences to the
    user's ID so each account's theme is stored independently.
  - Wired `resetToDefaults()` and `loadPrefsForUser()` into the sidebar layout's
    logout and session-restore flows via a swappable `storageRef` in
    `ThemeContext`.
<img width="402" height="563" alt="image" src="https://github.com/user-attachments/assets/d510310e-f2e7-4384-a258-6aa167b9cc90" />

<img width="317" height="910" alt="image" src="https://github.com/user-attachments/assets/c2bf3216-d85f-4396-9f72-188ffe009e42" />

  ---

  ### Categories — full system overhaul

  - **Form was using completely wrong hardcoded UUIDs** for all 10 categories.
    Replaced with a dynamic `useCategories()` hook (TanStack Query, 1 h
    stale time) so the select always reflects the real database.
  - Added 4 new categories: **Housing**, **Food & Drinks**, **Gaming**, **Music**
    — with icons and a Supabase migration
    (`20260421130000_add_more_categories.sql`).
  - Removed **Services** from the browse-by-category row (it's a listing type,
    not a category).
  - Adopted the `CATEGORY_DISPLAY` / `CATEGORY_ORDER` name-keyed pattern from
    the team's PR #218 so the homepage icons are always in sync with the DB
    without hardcoded UUIDs.

  ---

  ### Homepage

  - **Welcome banner** redesigned: full-width gradient card
    (`--color-primary-dark → --color-primary`), animated count-up stats in a
    3-column grid (Active Listings · Active Users · New Today).
  - **Browse by Category** row: horizontal scroll on mobile, 13-column grid on
    desktop (`lg:grid-cols-[repeat(13,minmax(0,1fr))]`).
  - Category labels capped to the button width (`w-16`), dropped to `text-xs`,
    and `line-clamp-2` prevents long names (e.g. "School Supplies",
    "Sports & Fitness") from overflowing into adjacent tiles.
  - Wishlist hover button: label expands smoothly on hover (`max-w-0 →
    max-w-[96px]`), removed trailing gap artifact.
  - Removed dead `useEffect(() => {}, [listingsRefreshKey])` that was running
    on every refresh but doing nothing.
<img width="1917" height="565" alt="image" src="https://github.com/user-attachments/assets/c34c5fc5-9ea5-40f6-86fe-2010766bf884" />

  ---

  ### Listing form & detail page

  - **Type toggle (Item / Service) is disabled in edit mode** — you cannot
    change a listing's type after creation. The UI shows a note and reduces
    opacity to communicate this.
  - **Publish validation is now type-aware**: item listings check `condition`
    and `quantity ≥ 1`; service listings check `duration_minutes > 0`.
    Previously, type-specific fields were not validated before publishing.

  ---

  ### Page header — responsive fixes

  - Logo shrunk from `size-14` to `size-9` so it doesn't dominate on larger
    screens.
  - Search bar is now always in-flow (`flex-1 min-w-0`) between the logo and
    the right controls — it fills exactly the available gap and shrinks
    gracefully at every screen size.
  - Removed the two-row mobile approach (search bar no longer drops below the
    logo/avatar on small screens).
  - About / Help / Contact links hidden below `md` to keep the nav uncluttered
    on tablet and mobile.

  ---

  ### Merge — PR #218 (Fix/pageCSS)

  Pulled teammate's `develop` changes and resolved conflicts in `form.tsx`,
  `page-header.tsx`, and `index.tsx`:

  - Kept our responsive layout, gradient banner, and smaller logo.
  - Adopted their `useCategories` hook and `CATEGORY_DISPLAY`/`CATEGORY_ORDER`
    pattern.
  - Removed the show/hide category toggle (single-row grid works for all 13).
  - Dropped the duplicate manual `getCategories` fetch in `form.tsx` in favour
    of the shared hook.